### PR TITLE
added 'Blender: ' to all command names for easier discoverability

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,19 +27,19 @@
         "commands": [
             {
                 "command": "b3ddev.startBlender",
-                "title": "Start Blender"
+                "title": "Blender: Start Blender"
             },
             {
                 "command": "b3ddev.newAddon",
-                "title": "New Blender Addon"
+                "title": "Blender: New Blender Addon"
             },
             {
                 "command": "b3ddev.launchAddon",
-                "title": "Launch Addon"
+                "title": "Blender: Launch Addon"
             },
             {
                 "command": "b3ddev.updateAddon",
-                "title": "Update Addon"
+                "title": "Blender: Update Addon"
             }
         ],
         "configuration": [


### PR DESCRIPTION
Hi. Nice.
simple addition.
It doesn't work yet for me (on Manjaro Linux).
Will see if i can figure out why.