### PR TITLE
Remove link to addon directory at exit of blender

### DIFF
--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -5,6 +5,7 @@ import traceback
 from pathlib import Path
 from . communication import send_dict_as_json
 from . environment import user_addon_directory, addon_directories
+import atexit
 
 def setup_addon_links(addons_to_load):
     if not os.path.exists(user_addon_directory):
@@ -46,6 +47,7 @@ def create_link_in_user_addon_directory(directory, link_path):
         _winapi.CreateJunction(str(directory), str(link_path))
     else:
         os.symlink(str(directory), str(link_path), target_is_directory=True)
+    atexit.register(os.remove, link_path)
 
 def is_in_any_addon_directory(module_path):
     for path in addon_directories:

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -38,6 +38,10 @@ def load(addons_to_load):
             traceback.print_exc()
             send_dict_as_json({"type" : "enableFailure", "addonPath" : str(source_path)})
 
+def remove_link_in_user_addon_directory(link_path):
+    if os.path.exists(link_path):
+        os.remove(link_path)
+
 def create_link_in_user_addon_directory(directory, link_path):
     if os.path.exists(link_path):
         os.remove(link_path)
@@ -47,7 +51,7 @@ def create_link_in_user_addon_directory(directory, link_path):
         _winapi.CreateJunction(str(directory), str(link_path))
     else:
         os.symlink(str(directory), str(link_path), target_is_directory=True)
-    atexit.register(os.remove, link_path)
+    atexit.register(remove_link_in_user_addon_directory, link_path)
 
 def is_in_any_addon_directory(module_path):
     for path in addon_directories:


### PR DESCRIPTION
Currently the python code loaded by blender through the VS code extension creates a symlink from the blender addons folder to the source code of the addon opened in VS code.

This pull requests remove created symlinks in order to put back the addons folder of the user in its previous state.

You can reject the pull request if you think the symlink should stay in the addons folder. In my opinion the blender installation or user folder should not me modified after the debug session has ended.

One other thing I want to add is disabling the extension when blender exits in order to get a full cleanup. However I did not found a way to do that (here is a post I have opened to ask for information on that https://devtalk.blender.org/t/running-python-code-just-before-blender-exits/10803/2).

Btw, thank you for your work on this extension, it saves so much development time ! 👍 