### PR TITLE
Allow Gizmo and GizmoGroup types to be picked inside auto_load.py

### DIFF
--- a/pythonFiles/templates/addons/with_auto_load/auto_load.py
+++ b/pythonFiles/templates/addons/with_auto_load/auto_load.py
@@ -128,7 +128,8 @@ def get_register_base_types():
         "Panel", "Operator", "PropertyGroup",
         "AddonPreferences", "Header", "Menu",
         "Node", "NodeSocket", "NodeTree",
-        "UIList", "RenderEngine"
+        "UIList", "RenderEngine",
+        "Gizmo", "GizmoGroup"
     ])
 
 


### PR DESCRIPTION
For folks implementing their own custom Gizmo's, auto_load.py needs to be able to pick up both bpy.types.Gizmo and bpy.types.GizmoGroup.