### PR TITLE
Disable justMyCode debugging

### DIFF
--- a/src/python_debugging.ts
+++ b/src/python_debugging.ts
@@ -23,6 +23,7 @@ function attachPythonDebugger(port: number, pathMappings: PathMapping[] = []) {
         port: port,
         host: 'localhost',
         pathMappings: pathMappings,
+        justMyCode: false,
     };
     vscode.debug.startDebugging(undefined, configuration);
 }


### PR DESCRIPTION
If this option is missing it is impossible to debug into Python libraries
that the Blender add-on is calling. This should later probably be made 
configurable in the settings but for now this is an easy fix.