### PR TITLE
Add colorama to required packages

### DIFF
--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -7,7 +7,7 @@ def startup(editor_address, addons_to_load, allow_modify_external_python):
 
     from . import installation
     installation.ensure_packages_are_installed(
-        ["debugpy", "flask", "requests"],
+        ["debugpy", "flask", "requests", "colorama"],
         allow_modify_external_python)
 
     from . import load_addons


### PR DESCRIPTION
The version of flask that blender_vscode installed was giving an error that colorama wasn't found.