### PR TITLE
Change scope of "blender.executables" to "resource"

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
         "properties": {
           "blender.executables": {
             "type": "array",
-            "scope": "application",
+            "scope": "resource",
             "description": "Paths to Blender executables.",
             "items": {
               "type": "object",


### PR DESCRIPTION
This is super useful if the versions of blender executables are managed workspace-wide (like if you have them in the same repo as add-ons). Then you can just point the paths for everybody in workspace settings and individual developers don't have to setup the extension themselves.

This doesn't change existing behaviour, you can still have it setup in application, but if the workspace overrides it then it uses the workspace config.

 