### PR TITLE
Support configuration of any environment variables on Blender start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+
+### Added
+- New `blender.environmentVariables` option. Can be used to define environment variables passed to
+blender on `Blender Start`.
+
+### Changed
+- Changed scope of `blender.executables` to `resource`. The value is firstly looked up in workspace
+settings before user settings.
+
+### Fixed
+
 ## [0.0.17] - 2022-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -211,6 +211,18 @@
             "items": {
               "type": "string"
             }
+          },
+          "blender.environmentVariables": {
+            "type": "object",
+            "scope": "resource",
+            "title": "Startup Environment Variables",
+            "description": "Environment variables set before Blender starts. Keys of the object are used as environment variable names, values as values.",
+            "examples": [
+              {
+                "BLENDER_USER_SCRIPTS": "C:/custom_scripts_folder",
+                "BLENDER_USER_CONFIG": "C:/custom_user_config"
+              }
+            ]
           }
         }
       }

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -195,5 +195,6 @@ async function getBlenderLaunchEnv() {
         ADDONS_TO_LOAD: JSON.stringify(loadDirsWithNames),
         EDITOR_PORT: getServerPort().toString(),
         ALLOW_MODIFY_EXTERNAL_PYTHON: <boolean>config.get('allowModifyExternalPython') ? 'yes' : 'no',
+        ...<object>config.get("environmentVariables", {}),
     };
 }


### PR DESCRIPTION
When you use the same blender for development and also for art you can messup the installation of addons that you actually want to use with the symlinks from the vscode integration. This results in having the same addon twice (one from vscode, one from Blender installation from prefs).

Using the new "environmentVariables" config it is possible to specify e. g. SCRIPTS and CONFIG folders in order to automatically point them to some controlled location when developing.

```
    "blender.environmentVariables": {
        "BLENDER_USER_SCRIPTS": "C:/tmp/scripts",
        "BLENDER_USER_CONFIG": "C:/tmp/config"
    },
```