### PR TITLE
New command 'blender.startDefault'

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "activationEvents": [
     "onCommand:blender.start",
+    "onCommand:blender.startDefault",
     "onCommand:blender.stop",
     "onCommand:blender.build",
     "onCommand:blender.buildAndStart",
@@ -39,6 +40,11 @@
       {
         "command": "blender.start",
         "title": "Start",
+        "category": "Blender"
+      },
+      {
+        "command": "blender.startDefault",
+        "title": "Start Default",
         "category": "Blender"
       },
       {
@@ -125,6 +131,11 @@
                 "isDebug": {
                   "type": "boolean",
                   "description": "Is this executable a debug build.",
+                  "default": false
+                },
+                "isDefault": {
+                  "type": "boolean",
+                  "description": "Mark this executable as default for the Start Default command",
                   "default": false
                 }
               }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import {
 export function activate(context: vscode.ExtensionContext) {
     let commands: [string, () => Promise<void>][] = [
         ['blender.start', COMMAND_start],
+        ['blender.startDefault', COMMAND_startDefault],
         ['blender.stop', COMMAND_stop],
         ['blender.build', COMMAND_build],
         ['blender.buildAndStart', COMMAND_buildAndStart],
@@ -73,6 +74,10 @@ async function COMMAND_start() {
     else {
         await BlenderExecutable.LaunchDebug(blenderFolder);
     }
+}
+
+async function COMMAND_startDefault() {
+    await BlenderExecutable.LaunchDefault()
 }
 
 async function COMMAND_stop() {


### PR DESCRIPTION
Launches blender executable without prompting user to select version based on 'defaultExecutableIndex' settings value. By default this launches first Blender available.

![image](https://user-images.githubusercontent.com/32932478/190641564-bcea6495-954b-4c5d-bab8-8d801ef43595.png)

Closes #114 #102 