### PR TITLE
Log mappings + reorder them to fix issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- "Blender: Run Script" will no longer open read-only file when hitting debug point (#142)
+
 ## [0.0.21] - 2024-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The preferred way to insert this comment is to execute the `Blender: Set Script 
 - Make sure you use the newest version of VS Code.
 - Use the latest Blender version from https://builder.blender.org/.
 - If your Blender does not use its own Python version, enable `blender.allowModifyExternalPython` or install the packages in the error message manually (currently `debugpy`, `flask` and `requests` are required).
+- Look in VS Code output window.
 
 ## Status
 

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -8,7 +8,7 @@ include_dir = Path(__file__).parent / "include"
 sys.path.append(str(include_dir))
 
 import blender_vscode
-print(json.loads(os.environ['ADDONS_TO_LOAD']))
+print("ADDONS_TO_LOAD", json.loads(os.environ['ADDONS_TO_LOAD']))
 
 try:
     blender_vscode.startup(

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -9,6 +9,7 @@ import { letUserPickItem } from './select_utils';
 import { getConfig, cancel, runTask } from './utils';
 import { AddonWorkspaceFolder } from './addon_folder';
 import { BlenderWorkspaceFolder } from './blender_folder';
+import { outputChannel } from './extension';
 
 
 export class BlenderExecutable {
@@ -51,11 +52,14 @@ export class BlenderExecutable {
     }
 
     public async launch() {
+        const blenderArgs = getBlenderLaunchArgs()
         let execution = new vscode.ProcessExecution(
             this.path,
-            getBlenderLaunchArgs(),
+            blenderArgs,
             { env: await getBlenderLaunchEnv() }
         );
+        outputChannel.appendLine(`Starting blender: ${this.path} ${blenderArgs.join(' ')}`)
+        outputChannel.appendLine('With ENV Vars: ' + JSON.stringify(execution.options?.env, undefined, 2))
 
         await runTask('blender', execution);
     }

--- a/src/communication.ts
+++ b/src/communication.ts
@@ -86,14 +86,14 @@ export class BlenderInstances {
             }
 
             for (let instance of this.instances) {
-                instance.ping().then(() => addInstance(instance)).catch(() => {});
+                instance.ping().then(() => addInstance(instance)).catch(() => { });
             }
             setTimeout(() => resolve(responsiveInstances.slice()), timeout);
         });
     }
 
     sendToResponsive(data: object, timeout: number = RESPONSIVE_LIMIT_MS) {
-        for (let instance of this.instances) {
+        for (const instance of this.instances) {
             instance.isResponsive(timeout).then(responsive => {
                 if (responsive) instance.post(data);
             }).catch();
@@ -101,7 +101,7 @@ export class BlenderInstances {
     }
 
     sendToAll(data: object) {
-        for (let instance of this.instances) {
+        for (const instance of this.instances) {
             instance.post(data);
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,27 +13,16 @@ import {
     COMMAND_openScriptsFolder
 } from './scripts';
 
-let outputChannel: vscode.OutputChannel;
+export let outputChannel: vscode.OutputChannel;
 
-/**
- * Prints the given content on the output channel.
- *
- * @param content The content to be printed.
- * @param reveal Whether the output channel should be revealed.
- */
-export const printChannelOutput = (content: string, reveal = false): void => {
-    outputChannel.appendLine(content);
-    if (reveal) {
-        outputChannel.show(true);
-    }
-};
 
 /* Registration
  *********************************************/
 
 export function activate(context: vscode.ExtensionContext) {
     outputChannel = vscode.window.createOutputChannel("Blender debugpy");
-    printChannelOutput("activated...", true);
+    outputChannel.appendLine("Addon staring.");
+    outputChannel.show(true);
 
     let commands: [string, () => Promise<void>][] = [
         ['blender.start', COMMAND_start],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,28 @@ import {
     COMMAND_openScriptsFolder
 } from './scripts';
 
+let outputChannel: vscode.OutputChannel;
+
+/**
+ * Prints the given content on the output channel.
+ *
+ * @param content The content to be printed.
+ * @param reveal Whether the output channel should be revealed.
+ */
+export const printChannelOutput = (content: string, reveal = false): void => {
+    outputChannel.appendLine(content);
+    if (reveal) {
+        outputChannel.show(true);
+    }
+};
+
+/* Registration
+ *********************************************/
+
 export function activate(context: vscode.ExtensionContext) {
+    outputChannel = vscode.window.createOutputChannel("Blender debugpy");
+    printChannelOutput("activated...", true);
+
     let commands: [string, () => Promise<void>][] = [
         ['blender.start', COMMAND_start],
         ['blender.stop', COMMAND_stop],

--- a/src/python_debugging.ts
+++ b/src/python_debugging.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { BlenderWorkspaceFolder } from './blender_folder';
 import { getStoredScriptFolders } from './scripts';
 import { AddonPathMapping } from './communication';
+import { printChannelOutput } from './extension';
 
 type PathMapping = { localRoot: string, remoteRoot: string };
 
@@ -24,6 +25,13 @@ function attachPythonDebugger(port: number, pathMappings: PathMapping[] = []) {
         host: 'localhost',
         pathMappings: pathMappings,
     };
+
+    // log config (reuse common output)
+    // let logConfig = vscode.window.createOutputChannel("Blender debugpy [tmp]");
+    // logConfig.appendLine("Configuration: " + JSON.stringify(configuration, undefined, 2));
+    // logConfig.show();
+    printChannelOutput("configuration: " + JSON.stringify(configuration, undefined, 2));
+
     vscode.debug.startDebugging(undefined, configuration);
 }
 

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -5,12 +5,14 @@ import { RunningBlenders } from './communication';
 import { letUserPickItem } from './select_utils';
 import { getAreaTypeItems } from './data_loader';
 import { getConfig, cancel, addFolderToWorkspace, getRandomString, pathExists, copyFile } from './utils';
+import { outputChannel } from './extension';
 
 export async function COMMAND_runScript(): Promise<void> {
     let editor = vscode.window.activeTextEditor;
     if (editor === undefined) return Promise.reject(new Error('no active script'));
 
-    let document = editor.document;
+    const document = editor.document;
+    outputChannel.appendLine(`Blender: Run Script: ${document.uri.fsPath}`)
     await document.save();
     RunningBlenders.sendToResponsive({ type: 'script', path: document.uri.fsPath });
 }


### PR DESCRIPTION
My fix to the issues related to https://github.com/JacquesLucke/blender_vscode/issues/140
* Logs the mapping json to a vscode logging output
* Reorders the mappings to fix breakpoints being triggered in a read-only state instead of the source file

> This fix works well for me, but might be worth testing it in other scenarios.