### PR TITLE
addon_folders.ts: assign scheme to URIs created for mockups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@
 - Remove duplicate links to development (VSCode) directory (#172)
 - Remove broken links in addon and extension dir (#172)
 
-### Changed 
-- Updated dependencies. Now oldest supported VS Code version is `1.28.0`. ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
+### Changed
+- Updated dependencies. Now oldest supported VS Code version is `1.28.0` - version from September 2018. ([#147](https://github.com/JacquesLucke/blender_vscode/pull/147))
 - Addon_update operator: Check more precisely which module to delete (#175)
 - Formatted all python code with `black -l 120` (#167)
 - Fix most of the user reported permission denied errors by changing python packages directory ([#177](https://github.com/JacquesLucke/blender_vscode/pull/177)):
@@ -26,7 +26,7 @@
 - setting `blender.allowModifyExternalPython` is now deprecated ([#177](https://github.com/JacquesLucke/blender_vscode/pull/177))
 
 ### Fixed
-- Path to addon indicated by [`blender.addonFolders`](vscode://settings/blender.addonFolders) now works correctly for non-system drive (usually `C:`) on Windows ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
+- Path to addon indicated by [`blender.addonFolders`](vscode://settings/blender.addonFolders) now works correctly for non-system drive (usually `C:`) on Windows ([#147](https://github.com/JacquesLucke/blender_vscode/pull/147))
 - Pinned requests to version 2.29 to maintain compatibility with blender 2.80 ([#177](https://github.com/JacquesLucke/blender_vscode/pull/177))
 - Find correct python path for blender 2.92 and before (#174). This partly fixes compatibility with blender 2.80.
 - "Blender: Run Script" will no longer open read-only file when hitting debug point (#142)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Updated dependencies. Now oldest supported VS Code version is `1.28.0`. ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
 
 ### Fixed
-- Path to addon indicated by [`blender.addonFolders`](vscode://settings/blender.addonFolders) now works corectly for non `C:` drive on Windows ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
+- Path to addon indicated by [`blender.addonFolders`](vscode://settings/blender.addonFolders) now works correctly for non-system drive (usually `C:`) on Windows ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
 
 ## [0.0.21] - 2024-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+- Updated dependencies. Now oldest supported VS Code version is `1.28.0`. ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
+
+### Fixed
+- Path to addon indicated by [`blender.addonFolders`](vscode://settings/blender.addonFolders) now works corectly for non `C:` drive on Windows ([#137](https://github.com/JacquesLucke/blender_vscode/pull/147))
+
 ## [0.0.21] - 2024-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -274,7 +274,7 @@
     "@types/request": "^2.48.1",
     "@types/vscode": "^1.28.0",
     "tslint": "^5.8.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.5.2"
   },
   "dependencies": {
     "request": "^2.87.0"

--- a/package.json
+++ b/package.json
@@ -231,16 +231,15 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
-    "watch": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "watch": "tsc -watch -p ./"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.25",
     "@types/request": "^2.48.1",
+    "@types/vscode": "^1.28.0",
     "tslint": "^5.8.0",
-    "typescript": "^3.5.1",
-    "vscode": "^1.1.21"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "request": "^2.87.0"

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -20,12 +20,11 @@ export class AddonWorkspaceFolder {
         // search workspace folders instead.
         let addonFolders = await foldersToWorkspaceFoldersMockup(
             <string[]>getConfig().get('addonFolders'));
-        if (addonFolders.length === 0) {
-            addonFolders = getWorkspaceFolders();
-        }
+        
+        let searchableFolders = addonFolders.length !== 0 ? addonFolders : getWorkspaceFolders(); 
 
         let folders = [];
-        for (let folder of addonFolders) {
+        for (let folder of searchableFolders) {
             let addon = new AddonWorkspaceFolder(folder);
             if (await addon.hasAddonEntryPoint()) {
                 folders.push(addon);

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -157,7 +157,7 @@ async function foldersToWorkspaceFoldersMockup(folders: string[]) {
 
         mockups.push({
             "name" : path.basename(absolutePath),
-            "uri": vscode.Uri.parse(absolutePath),
+            "uri": vscode.Uri.from({ scheme: "file", path: absolutePath }),
             "index": i
         });
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export function handleErrors(func: () => Promise<void>) {
         try {
             await func();
         }
-        catch (err) {
+        catch (err: any) {
             if (err instanceof Error) {
                 if (err.message !== CANCEL) {
                     vscode.window.showErrorMessage(err.message);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export function handleErrors(func: () => Promise<void>) {
         try {
             await func();
         }
-        catch (err) {
+        catch (err: any) {
             if (err.message !== CANCEL) {
                 vscode.window.showErrorMessage(err.message);
             }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "ES2020",
         "outDir": "out",
         "lib": [
-            "es6",
-            "esnext.asynciterable"
+            "es2020"
         ],
         "sourceMap": true,
         "rootDir": "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "target": "es6",
         "outDir": "out",
         "lib": [
-            "es6"
+            "es6",
+            "esnext.asynciterable"
         ],
         "sourceMap": true,
         "rootDir": "src",


### PR DESCRIPTION
Correctly constructs URI objects that are passed to functions related to searching addon files.

Additionally, vscode dependency is updated to a non-depricated version, compatible with the same engine version, and typescript is updated to a version that is compatible with that version.

Small changes in addon_folder.ts are to make the new typescript version happy. 

Closes #146 