### PR TITLE
Support Reload on Save with new Extensions Platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
-    "@types/node": "^8.10.66",
+    "@types/node": "^8.10.25",
     "@types/request": "^2.48.1",
     "tslint": "^5.8.0",
     "typescript": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",
-    "@types/node": "^8.10.25",
+    "@types/node": "^8.10.66",
     "@types/request": "^2.48.1",
     "tslint": "^5.8.0",
     "typescript": "^3.5.1",

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -130,6 +130,16 @@ async function tryFindActualAddonFolder(root: string) {
 }
 
 async function folderContainsAddonEntry(folderPath: string) {
+    let tomlPath = path.join(folderPath, "blender_manifest.toml");
+    if (await pathExists(tomlPath)) {
+        try {
+            readTextFile(tomlPath);
+            return true;
+        } catch (_b) {
+            return false;
+        }
+    }
+        
     let initPath = path.join(folderPath, '__init__.py');
     try {
         let content = await readTextFile(initPath);

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -130,14 +130,9 @@ async function tryFindActualAddonFolder(root: string) {
 }
 
 async function folderContainsAddonEntry(folderPath: string) {
-    let tomlPath = path.join(folderPath, "blender_manifest.toml");
-    if (await pathExists(tomlPath)) {
-        try {
-            readTextFile(tomlPath);
-            return true;
-        } catch (_b) {
-            return false;
-        }
+    let manifestPath = path.join(folderPath, "blender_manifest.toml");
+    if (await pathExists(manifestPath)) {
+        return true;
     }
         
     let initPath = path.join(folderPath, '__init__.py');


### PR DESCRIPTION
This commit adds a new function `folderContainsAddonEntry` to check if a folder contains an addon entry. It first checks for the presence of a `blender_manifest.toml` file and if found, If the file is not found or cannot be read, it falls back to checking for the presence of an `__init__.py` file.