### PR TITLE
Add support for developing Blender 4.2 extensions as well as legacy addons

### DIFF
--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -27,12 +27,12 @@ def startup(editor_address, addons_to_load: list[AddonInfo], allow_modify_extern
     from . import communication
     communication.setup(editor_address, path_mappings)
 
-    load_addons.load(addons_to_load)
-
     from . import operators, ui
 
     ui.register()
     operators.register()
+
+    load_addons.load(addons_to_load)
 
 def handle_fatal_error(message):
     print()

--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -9,7 +9,6 @@ import bpy
 class AddonInfo:
     load_dir: Path
     module_name: str
-    module_path: str
 
 
 def startup(editor_address, addons_to_load: list[AddonInfo], allow_modify_external_python):

--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -1,7 +1,18 @@
-import bpy
 import sys
+from dataclasses import dataclass
+from pathlib import Path
 
-def startup(editor_address, addons_to_load, allow_modify_external_python):
+import bpy
+
+
+@dataclass
+class AddonInfo:
+    load_dir: Path
+    module_name: str
+    module_path: str
+
+
+def startup(editor_address, addons_to_load: list[AddonInfo], allow_modify_external_python):
     if bpy.app.version < (2, 80, 34):
         handle_fatal_error("Please use a newer version of Blender")
 
@@ -18,8 +29,7 @@ def startup(editor_address, addons_to_load, allow_modify_external_python):
 
     load_addons.load(addons_to_load)
 
-    from . import ui
-    from . import operators
+    from . import operators, ui
 
     ui.register()
     operators.register()

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -16,5 +16,13 @@ else:
 
 version = bpy.app.version
 scripts_folder = blender_path.parent / f"{version[0]}.{version[1]}" / "scripts"
-user_addon_directory = Path(bpy.utils.user_resource('SCRIPTS', path="addons"))
+
+
+def get_user_addon_directory(source_path: Path):
+    if version >= (4, 2, 0) and next(source_path.glob("blender_manifest.toml"), None):
+        return Path(bpy.utils.user_resource("EXTENSIONS", path="user_default"))
+    else:
+        return Path(bpy.utils.user_resource('SCRIPTS', path="addons"))
+
+
 addon_directories = tuple(map(Path, addon_utils.paths()))

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -4,6 +4,8 @@ import addon_utils
 from pathlib import Path
 import platform
 
+from .utils import is_addon_legacy
+
 python_path = Path(sys.executable)
 blender_path = Path(bpy.app.binary_path)
 blender_directory = blender_path.parent
@@ -19,7 +21,7 @@ scripts_folder = blender_path.parent / f"{version[0]}.{version[1]}" / "scripts"
 
 
 def get_user_addon_directory(source_path: Path):
-    if version >= (4, 2, 0) and next(source_path.glob("blender_manifest.toml"), None):
+    if is_addon_legacy(source_path):
         return Path(bpy.utils.user_resource("EXTENSIONS", path="user_default"))
     else:
         return Path(bpy.utils.user_resource('SCRIPTS', path="addons"))

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -4,8 +4,6 @@ import addon_utils
 from pathlib import Path
 import platform
 
-from .utils import is_addon_legacy
-
 python_path = Path(sys.executable)
 blender_path = Path(bpy.app.binary_path)
 blender_directory = blender_path.parent
@@ -18,13 +16,6 @@ else:
 
 version = bpy.app.version
 scripts_folder = blender_path.parent / f"{version[0]}.{version[1]}" / "scripts"
-
-
-def get_user_addon_directory(source_path: Path):
-    if is_addon_legacy(source_path):
-        return Path(bpy.utils.user_resource('SCRIPTS', path="addons"))
-    else:
-        return Path(bpy.utils.user_resource("EXTENSIONS", path="user_default"))
 
 
 addon_directories = tuple(map(Path, addon_utils.paths()))

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -22,9 +22,9 @@ scripts_folder = blender_path.parent / f"{version[0]}.{version[1]}" / "scripts"
 
 def get_user_addon_directory(source_path: Path):
     if is_addon_legacy(source_path):
-        return Path(bpy.utils.user_resource("EXTENSIONS", path="user_default"))
-    else:
         return Path(bpy.utils.user_resource('SCRIPTS', path="addons"))
+    else:
+        return Path(bpy.utils.user_resource("EXTENSIONS", path="user_default"))
 
 
 addon_directories = tuple(map(Path, addon_utils.paths()))

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -16,6 +16,4 @@ else:
 
 version = bpy.app.version
 scripts_folder = blender_path.parent / f"{version[0]}.{version[1]}" / "scripts"
-
-
 addon_directories = tuple(map(Path, addon_utils.paths()))

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -3,30 +3,26 @@ import bpy
 import sys
 import traceback
 from pathlib import Path
+
+from .utils import is_addon_legacy
 from . communication import send_dict_as_json
 from . environment import get_user_addon_directory, addon_directories
 
 
-def setup_addon_links(addons_to_load):
-
-    user_addon_directory = get_user_addon_directory(Path(next(addons_to_load.keys())))
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    print(f"USER ADDON: {user_addon_directory}")
-    if not os.path.exists(user_addon_directory):
-        os.makedirs(user_addon_directory)
-
-    if not str(user_addon_directory) in sys.path:
-        sys.path.append(str(user_addon_directory))
+def setup_addon_links(addons_to_load: tuple):
 
     path_mappings = []
 
     for source_path, module_name in addons_to_load:
+        user_addon_directory = get_user_addon_directory(Path(source_path))
+        print(f"USER ADDON: {user_addon_directory}")
+
+        if not os.path.exists(user_addon_directory):
+            os.makedirs(user_addon_directory)
+
+        if not str(user_addon_directory) in sys.path:
+            sys.path.append(str(user_addon_directory))
+
         if is_in_any_addon_directory(source_path):
             load_path = source_path
         else:
@@ -42,6 +38,20 @@ def setup_addon_links(addons_to_load):
 
 def load(addons_to_load):
     for source_path, module_name in addons_to_load:
+        if is_addon_legacy(Path(source_path)):
+            module_name = "bl_ext.user_default." + module_name
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+
         try:
             bpy.ops.preferences.addon_enable(module=module_name)
         except:

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -51,7 +51,6 @@ def load(addons_to_load: list[AddonInfo]):
             addon_name = addon_info.module_name
         else:
             bpy.ops.extensions.repo_refresh_all()
-            # addon_name = "bl_ext.user_default." + addon_info.module_path
             addon_name = "bl_ext.user_default." + addon_info.module_name
 
         try:

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -43,7 +43,8 @@ def load(addons_to_load: list[AddonInfo]):
             addon_name = addon_info.module_name
         else:
             bpy.ops.extensions.repo_refresh_all()
-            addon_name = addon_info.module_path
+            # addon_name = "bl_ext.user_default." + addon_info.module_path
+            addon_name = "bl_ext.user_default." + addon_info.module_name
 
         try:
             # bpy.ops.preferences.addon_enable(module=addon_name)

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -38,19 +38,23 @@ def setup_addon_links(addons_to_load: tuple):
 
 def load(addons_to_load):
     for source_path, module_name in addons_to_load:
-        # if is_addon_legacy(Path(source_path)):
-        #     module_name = "bl_ext.user_default." + module_name
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
-        #     print(module_name)
+        if is_addon_legacy(Path(source_path)):
+            bpy.ops.extensions.repo_refresh_all()
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
+            print(module_name)
 
         try:
             bpy.ops.preferences.addon_enable(module=module_name)

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -46,7 +46,8 @@ def load(addons_to_load: list[AddonInfo]):
             addon_name = addon_info.module_path
 
         try:
-            bpy.ops.preferences.addon_enable(module=addon_name)
+            # bpy.ops.preferences.addon_enable(module=addon_name)
+            bpy.ops.dev.update_addon(module_name=addon_name)
         except:
             traceback.print_exc()
             send_dict_as_json({"type": "enableFailure", "addonPath": str(addon_info.load_dir)})

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -1,20 +1,22 @@
 import os
-import bpy
 import sys
 import traceback
 from pathlib import Path
 
+import bpy
+
+from . import AddonInfo
+from .communication import send_dict_as_json
+from .environment import addon_directories, get_user_addon_directory
 from .utils import is_addon_legacy
-from . communication import send_dict_as_json
-from . environment import get_user_addon_directory, addon_directories
 
 
-def setup_addon_links(addons_to_load: tuple):
+def setup_addon_links(addons_to_load: list[AddonInfo]):
 
     path_mappings = []
 
-    for source_path, module_name in addons_to_load:
-        user_addon_directory = get_user_addon_directory(Path(source_path))
+    for addon_info in addons_to_load:
+        user_addon_directory = get_user_addon_directory(Path(addon_info.load_dir))
         print(f"USER ADDON: {user_addon_directory}")
 
         if not os.path.exists(user_addon_directory):
@@ -23,44 +25,28 @@ def setup_addon_links(addons_to_load: tuple):
         if not str(user_addon_directory) in sys.path:
             sys.path.append(str(user_addon_directory))
 
-        if is_in_any_addon_directory(source_path):
-            load_path = source_path
+        if is_in_any_addon_directory(addon_info.load_dir):
+            load_path = addon_info.load_dir
         else:
-            load_path = os.path.join(user_addon_directory, module_name)
-            create_link_in_user_addon_directory(source_path, load_path)
+            load_path = os.path.join(user_addon_directory, addon_info.module_name)
+            create_link_in_user_addon_directory(addon_info.load_dir, load_path)
 
-        path_mappings.append({
-            "src": str(source_path),
-            "load": str(load_path)
-        })
+        path_mappings.append({"src": str(addon_info.load_dir), "load": str(load_path)})
 
     return path_mappings
 
-def load(addons_to_load):
-    for source_path, module_name in addons_to_load:
-        if is_addon_legacy(Path(source_path)):
+
+def load(addons_to_load: list[AddonInfo]):
+    for addon_info in addons_to_load:
+        if is_addon_legacy(Path(addon_info.load_dir)):
             bpy.ops.extensions.repo_refresh_all()
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
 
         try:
-            bpy.ops.preferences.addon_enable(module=module_name)
+            bpy.ops.preferences.addon_enable(module=addon_info.module_path)
         except:
             traceback.print_exc()
-            send_dict_as_json({"type" : "enableFailure", "addonPath" : str(source_path)})
+            send_dict_as_json({"type": "enableFailure", "addonPath": str(addon_info.load_dir)})
+
 
 def create_link_in_user_addon_directory(directory, link_path):
     if os.path.exists(link_path):
@@ -68,9 +54,11 @@ def create_link_in_user_addon_directory(directory, link_path):
 
     if sys.platform == "win32":
         import _winapi
+
         _winapi.CreateJunction(str(directory), str(link_path))
     else:
         os.symlink(str(directory), str(link_path), target_is_directory=True)
+
 
 def is_in_any_addon_directory(module_path):
     for path in addon_directories:

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -38,19 +38,19 @@ def setup_addon_links(addons_to_load: tuple):
 
 def load(addons_to_load):
     for source_path, module_name in addons_to_load:
-        if is_addon_legacy(Path(source_path)):
-            module_name = "bl_ext.user_default." + module_name
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
-            print(module_name)
+        # if is_addon_legacy(Path(source_path)):
+        #     module_name = "bl_ext.user_default." + module_name
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
+        #     print(module_name)
 
         try:
             bpy.ops.preferences.addon_enable(module=module_name)

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -39,10 +39,14 @@ def setup_addon_links(addons_to_load: list[AddonInfo]):
 def load(addons_to_load: list[AddonInfo]):
     for addon_info in addons_to_load:
         if is_addon_legacy(Path(addon_info.load_dir)):
+            bpy.ops.preferences.addon_refresh()
+            addon_name = addon_info.module_name
+        else:
             bpy.ops.extensions.repo_refresh_all()
+            addon_name = addon_info.module_path
 
         try:
-            bpy.ops.preferences.addon_enable(module=addon_info.module_path)
+            bpy.ops.preferences.addon_enable(module=addon_name)
         except:
             traceback.print_exc()
             send_dict_as_json({"type": "enableFailure", "addonPath": str(addon_info.load_dir)})

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -4,9 +4,20 @@ import sys
 import traceback
 from pathlib import Path
 from . communication import send_dict_as_json
-from . environment import user_addon_directory, addon_directories
+from . environment import get_user_addon_directory, addon_directories
+
 
 def setup_addon_links(addons_to_load):
+
+    user_addon_directory = get_user_addon_directory(Path(next(addons_to_load.keys())))
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
+    print(f"USER ADDON: {user_addon_directory}")
     if not os.path.exists(user_addon_directory):
         os.makedirs(user_addon_directory)
 

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -22,7 +22,7 @@ def setup_addon_links(addons_to_load: list[AddonInfo]):
         if not os.path.exists(user_addon_directory):
             os.makedirs(user_addon_directory)
 
-        if not str(user_addon_directory) in sys.path:
+        if is_addon_legacy(Path(addon_info.load_dir)) and not str(user_addon_directory) in sys.path:
             sys.path.append(str(user_addon_directory))
 
         if is_in_any_addon_directory(addon_info.load_dir):

--- a/pythonFiles/include/blender_vscode/operators/addon_update.py
+++ b/pythonFiles/include/blender_vscode/operators/addon_update.py
@@ -38,11 +38,11 @@ class UpdateAddonOperator(bpy.types.Operator):
 
 def reload_addon_action(data):
     module_names = []
-    for name, path, dir in zip(data["names"], data["paths"], data["dirs"]):
+    for name, dir in zip(data["names"], data["dirs"]):
         if is_addon_legacy(Path(dir)):
             module_names.append(name)
         else:
-            module_names.append(path)
+            module_names.append("bl_ext.user_default." + name)
 
     for name in module_names:
         bpy.ops.dev.update_addon(module_name=name)

--- a/pythonFiles/include/blender_vscode/operators/addon_update.py
+++ b/pythonFiles/include/blender_vscode/operators/addon_update.py
@@ -2,7 +2,7 @@ import bpy
 import sys
 import traceback
 from bpy.props import *
-from .. utils import redraw_all
+from .. utils import is_addon_legacy, redraw_all
 from .. communication import send_dict_as_json, register_post_action
 
 class UpdateAddonOperator(bpy.types.Operator):
@@ -36,7 +36,14 @@ class UpdateAddonOperator(bpy.types.Operator):
         return {'FINISHED'}
 
 def reload_addon_action(data):
-    for name in data["names"]:
+    module_names = []
+    for name, path, dir in zip(data["names"], data["paths"], data["dirs"]):
+        if is_addon_legacy(dir):
+            module_names.append(name)
+        else:
+            module_names.append(path)
+
+    for name in module_names:
         bpy.ops.dev.update_addon(module_name=name)
 
 def register():

--- a/pythonFiles/include/blender_vscode/operators/addon_update.py
+++ b/pythonFiles/include/blender_vscode/operators/addon_update.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import bpy
 import sys
 import traceback
@@ -38,7 +39,7 @@ class UpdateAddonOperator(bpy.types.Operator):
 def reload_addon_action(data):
     module_names = []
     for name, path, dir in zip(data["names"], data["paths"], data["dirs"]):
-        if is_addon_legacy(dir):
+        if is_addon_legacy(Path(dir)):
             module_names.append(name)
         else:
             module_names.append(path)

--- a/pythonFiles/include/blender_vscode/utils.py
+++ b/pythonFiles/include/blender_vscode/utils.py
@@ -1,6 +1,11 @@
+from pathlib import Path
 import bpy
 import queue
 import traceback
+
+def is_addon_legacy(addon_dir: Path):
+    """Return whether an addon uses the legacy bl_info behavior, or the new blender_manifest behavior"""
+    return bpy.app.version >= (4, 2, 0) and next(addon_dir.glob("blender_manifest.toml"), None)
 
 def redraw_all():
     for window in bpy.context.window_manager.windows:

--- a/pythonFiles/include/blender_vscode/utils.py
+++ b/pythonFiles/include/blender_vscode/utils.py
@@ -5,7 +5,11 @@ import traceback
 
 def is_addon_legacy(addon_dir: Path):
     """Return whether an addon uses the legacy bl_info behavior, or the new blender_manifest behavior"""
-    return bpy.app.version >= (4, 2, 0) and next(addon_dir.glob("blender_manifest.toml"), None)
+    if bpy.app.version < (4, 2, 0):
+        return True
+    if not (addon_dir / "blender_manifest.toml").exists():
+        return True
+    return False
 
 def redraw_all():
     for window in bpy.context.window_manager.windows:

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -16,7 +16,6 @@ else:
 print(json.loads(os.environ["ADDONS_TO_LOAD"]))
 
 try:
-    # addons_to_load = [blender_vscode.AddonInfo(**info) for info in json.loads(os.environ["ADDONS_TO_LOAD"])]
     addons_to_load = []
     for info in json.loads(os.environ["ADDONS_TO_LOAD"]):
         addon_info = blender_vscode.AddonInfo(**info)

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -3,20 +3,29 @@ import os
 import sys
 import traceback
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 include_dir = Path(__file__).parent / "include"
 sys.path.append(str(include_dir))
 
-import blender_vscode
+if TYPE_CHECKING:
+    from .include import blender_vscode
+else:
+    import blender_vscode
 
 print(json.loads(os.environ["ADDONS_TO_LOAD"]))
 
 try:
+    # addons_to_load = [blender_vscode.AddonInfo(**info) for info in json.loads(os.environ["ADDONS_TO_LOAD"])]
+    addons_to_load = []
+    for info in json.loads(os.environ["ADDONS_TO_LOAD"]):
+        addon_info = blender_vscode.AddonInfo(**info)
+        addon_info.load_dir = Path(addon_info.load_dir)
+        addons_to_load.append(addon_info)
+
     blender_vscode.startup(
         editor_address=f"http://localhost:{os.environ['EDITOR_PORT']}",
-        addons_to_load=tuple(
-            map(lambda x: (Path(x["load_dir"]), x["module_name"]), json.loads(os.environ["ADDONS_TO_LOAD"]))
-        ),
+        addons_to_load=addons_to_load,
         allow_modify_external_python=os.environ["ALLOW_MODIFY_EXTERNAL_PYTHON"] == "yes",
     )
 except Exception as e:

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -1,6 +1,6 @@
+import json
 import os
 import sys
-import json
 import traceback
 from pathlib import Path
 
@@ -8,14 +8,16 @@ include_dir = Path(__file__).parent / "include"
 sys.path.append(str(include_dir))
 
 import blender_vscode
-print(json.loads(os.environ['ADDONS_TO_LOAD']))
+
+print(json.loads(os.environ["ADDONS_TO_LOAD"]))
 
 try:
     blender_vscode.startup(
         editor_address=f"http://localhost:{os.environ['EDITOR_PORT']}",
-        addons_to_load=tuple(map(lambda x: (Path(x["load_dir"]), x["module_name"]),
-                                 json.loads(os.environ['ADDONS_TO_LOAD']))),
-        allow_modify_external_python=os.environ['ALLOW_MODIFY_EXTERNAL_PYTHON'] == "yes",
+        addons_to_load=tuple(
+            map(lambda x: (Path(x["load_dir"]), x["module_name"]), json.loads(os.environ["ADDONS_TO_LOAD"]))
+        ),
+        allow_modify_external_python=os.environ["ALLOW_MODIFY_EXTERNAL_PYTHON"] == "yes",
     )
 except Exception as e:
     if type(e) is not SystemExit:

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -1,6 +1,6 @@
-import json
 import os
 import sys
+import json
 import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 include_dir = Path(__file__).parent / "include"
 sys.path.append(str(include_dir))
 
+# Get proper type hinting without impacting runtime
 if TYPE_CHECKING:
     from .include import blender_vscode
 else:

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -89,7 +89,7 @@ export class AddonWorkspaceFolder {
         }
     }
 
- public async getLoadDirectory() {
+    public async getLoadDirectory() {
         let value = <string>getConfig(this.uri).get('addon.loadDirectory');
         if (value === 'auto') {
             return this.getSourceDirectory();

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -88,8 +88,8 @@ export class AddonWorkspaceFolder {
             return value;
         }
     }
-    
-    public async getLoadDirectory() {
+
+ public async getLoadDirectory() {
         let value = <string>getConfig(this.uri).get('addon.loadDirectory');
         if (value === 'auto') {
             return this.getSourceDirectory();

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import {
     getConfig, readTextFile, getWorkspaceFolders,
     getSubfolders, executeTask, getAnyWorkspaceFolder, pathExists
@@ -10,9 +11,11 @@ import {
 
 export class AddonWorkspaceFolder {
     folder: vscode.WorkspaceFolder;
+    isLegacy: boolean;
 
     constructor(folder: vscode.WorkspaceFolder) {
         this.folder = folder;
+        this.isLegacy = fs.existsSync(path.join(folder.uri.fsPath, "blender_manifest.toml"));
     }
 
     public static async All() {
@@ -82,7 +85,11 @@ export class AddonWorkspaceFolder {
     public async getModuleName() {
         let value = <string>getConfig(this.uri).get('addon.moduleName');
         if (value === 'auto') {
-            return path.basename(await this.getLoadDirectory());
+            let module_base = path.basename(await this.getLoadDirectory());
+            if (this.isLegacy) {
+                module_base = "bl_ext.user_default.".concat(module_base)
+            }
+            return module_base;
         }
         else {
             return value;

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -82,7 +82,7 @@ export class AddonWorkspaceFolder {
         };
     }
 
-    public async getModuleName() {
+    public async getModulePath() {
         let value = <string>getConfig(this.uri).get('addon.moduleName');
         if (value === 'auto') {
             let module_base = path.basename(await this.getLoadDirectory());
@@ -94,6 +94,14 @@ export class AddonWorkspaceFolder {
         else {
             return value;
         }
+    }
+
+    public async getModuleName() {
+        let path = await this.getModulePath();
+        if (this.isLegacy) {
+            return path.split(".").slice(-1)[0];
+        }
+        return path
     }
 
     public async getLoadDirectory() {

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -76,9 +76,11 @@ export class AddonWorkspaceFolder {
     public async getLoadDirectoryAndModuleName() {
         let load_dir = await this.getLoadDirectory();
         let module_name = await this.getModuleName();
+        let module_path = await this.getModulePath();
         return {
             'load_dir' : load_dir,
             'module_name' : module_name,
+            'module_path': module_path,
         };
     }
 

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -11,11 +11,9 @@ import {
 
 export class AddonWorkspaceFolder {
     folder: vscode.WorkspaceFolder;
-    isLegacy: boolean;
 
     constructor(folder: vscode.WorkspaceFolder) {
         this.folder = folder;
-        this.isLegacy = fs.existsSync(path.join(folder.uri.fsPath, "blender_manifest.toml"));
     }
 
     public static async All() {
@@ -53,6 +51,10 @@ export class AddonWorkspaceFolder {
         return <boolean>this.getConfig().get('addon.justMyCode');
     }
 
+    public async isLegacy() {
+        return fs.existsSync(path.join(await this.getSourceDirectory(), "blender_manifest.toml"))
+    }
+
     public async hasAddonEntryPoint() {
         try {
             let sourceDir = await this.getSourceDirectory();
@@ -88,7 +90,7 @@ export class AddonWorkspaceFolder {
         let value = <string>getConfig(this.uri).get('addon.moduleName');
         if (value === 'auto') {
             let module_base = path.basename(await this.getLoadDirectory());
-            if (this.isLegacy) {
+            if (await this.isLegacy()) {
                 module_base = "bl_ext.user_default.".concat(module_base)
             }
             return module_base;
@@ -100,7 +102,7 @@ export class AddonWorkspaceFolder {
 
     public async getModuleName() {
         let path = await this.getModulePath();
-        if (this.isLegacy) {
+        if (await this.isLegacy()) {
             return path.split(".").slice(-1)[0];
         }
         return path

--- a/src/addon_folder.ts
+++ b/src/addon_folder.ts
@@ -73,11 +73,9 @@ export class AddonWorkspaceFolder {
     public async getLoadDirectoryAndModuleName() {
         let load_dir = await this.getLoadDirectory();
         let module_name = await this.getModuleName();
-        let module_path = await this.getExtensionModulePath();
         return {
             'load_dir' : load_dir,
             'module_name' : module_name,
-            'module_path': module_path,
         };
     }
 
@@ -89,10 +87,6 @@ export class AddonWorkspaceFolder {
         else {
             return value;
         }
-    }
-    
-    public async getExtensionModulePath() {
-        return "bl_ext.user_default.".concat(await this.getModuleName())
     }
     
     public async getLoadDirectory() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ async function reloadAddons(addons: AddonWorkspaceFolder[]) {
     if (instances.length === 0) return;
 
     await rebuildAddons(addons);
-    let names = await Promise.all(addons.map(a => a.getModuleName()));
+    let names = await Promise.all(addons.map(a => a.getModulePath()));
     instances.forEach(instance => instance.post({ type: 'reload', names: names }));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,8 +118,10 @@ async function reloadAddons(addons: AddonWorkspaceFolder[]) {
     if (instances.length === 0) return;
 
     await rebuildAddons(addons);
-    let names = await Promise.all(addons.map(a => a.getModulePath()));
-    instances.forEach(instance => instance.post({ type: 'reload', names: names }));
+    let names = await Promise.all(addons.map(a => a.getModuleName()));
+    let paths = await Promise.all(addons.map(a => a.getModulePath()))
+    let dirs = await Promise.all(addons.map(a => a.folder.uri.fsPath))
+    instances.forEach(instance => instance.post({ type: 'reload', names: names, paths: paths, dirs: dirs}));
 }
 
 async function rebuildAddons(addons: AddonWorkspaceFolder[]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -120,7 +120,7 @@ async function reloadAddons(addons: AddonWorkspaceFolder[]) {
     await rebuildAddons(addons);
     let names = await Promise.all(addons.map(a => a.getModuleName()));
     let paths = await Promise.all(addons.map(a => a.getModulePath()))
-    let dirs = await Promise.all(addons.map(a => a.folder.uri.fsPath))
+    let dirs = await Promise.all(addons.map(a => a.getSourceDirectory()))
     instances.forEach(instance => instance.post({ type: 'reload', names: names, paths: paths, dirs: dirs}));
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,9 +119,9 @@ async function reloadAddons(addons: AddonWorkspaceFolder[]) {
 
     await rebuildAddons(addons);
     let names = await Promise.all(addons.map(a => a.getModuleName()));
-    let paths = await Promise.all(addons.map(a => a.getExtensionModulePath()))
-    let dirs = await Promise.all(addons.map(a => a.getSourceDirectory()))
-    instances.forEach(instance => instance.post({ type: 'reload', names: names, paths: paths, dirs: dirs}));
+    // Send source dirs so that the python script can determine if each addon is an extension or not.
+    let dirs = await Promise.all(addons.map(a => a.getSourceDirectory()));
+    instances.forEach(instance => instance.post({ type: 'reload', names: names, dirs: dirs}));
 }
 
 async function rebuildAddons(addons: AddonWorkspaceFolder[]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,7 +119,7 @@ async function reloadAddons(addons: AddonWorkspaceFolder[]) {
 
     await rebuildAddons(addons);
     let names = await Promise.all(addons.map(a => a.getModuleName()));
-    let paths = await Promise.all(addons.map(a => a.getModulePath()))
+    let paths = await Promise.all(addons.map(a => a.getExtensionModulePath()))
     let dirs = await Promise.all(addons.map(a => a.getSourceDirectory()))
     instances.forEach(instance => instance.post({ type: 'reload', names: names, paths: paths, dirs: dirs}));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,9 +46,11 @@ export function handleErrors(func: () => Promise<void>) {
         try {
             await func();
         }
-        catch (err: any) {
-            if (err.message !== CANCEL) {
-                vscode.window.showErrorMessage(err.message);
+        catch (err) {
+            if (err instanceof Error) {
+                if (err.message !== CANCEL) {
+                    vscode.window.showErrorMessage(err.message);
+                }
             }
         }
     };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export function handleErrors(func: () => Promise<void>) {
         try {
             await func();
         }
-        catch (err) {
+        catch (err: any) {
             if (err.message !== CANCEL) {
                 vscode.window.showErrorMessage(err.message);
             }


### PR DESCRIPTION
This adds support for automatically detecting whether an addon is an extension, and if it is, installing as one instead of as a legacy addon.

Main changes:
- If an addon has a top level `blender_manifest.toml` file, it is treated as an extension (in supported blender versions).
- If so, the python code creates the symlink in the extensions' directory, and prepends `bl_ext.user_default.` to the module name.
- Reloading an addon now also passes the list of addon source directories so that the python code can determine whether each one is an extension.
- Small refactor to the python startup script to use a dataclass to pass the `addons_to_load` rather than a tuple, makes it easier to know what info is available (could be reverted if it doesn't fit).

If an addon is not an extension, or if the Blender version is lower than 4.2, it will just be treated as a normal addon.