### PR TITLE
Fix #80: find correct python path for blender 2.92 and before

### DIFF
--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -1,6 +1,7 @@
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import List
 
 import bpy
 
@@ -11,7 +12,7 @@ class AddonInfo:
     module_name: str
 
 
-def startup(editor_address, addons_to_load: list[AddonInfo], allow_modify_external_python):
+def startup(editor_address, addons_to_load: List[AddonInfo], allow_modify_external_python):
     if bpy.app.version < (2, 80, 34):
         handle_fatal_error("Please use a newer version of Blender")
 

--- a/pythonFiles/include/blender_vscode/communication.py
+++ b/pythonFiles/include/blender_vscode/communication.py
@@ -6,7 +6,7 @@ import requests
 import threading
 from functools import partial
 from .utils import run_in_main_thread
-from .environment import blender_path, scripts_folder
+from .environment import blender_path, scripts_folder, python_path
 
 EDITOR_ADDRESS = None
 OWN_SERVER_PORT = None
@@ -52,6 +52,9 @@ def start_debug_server():
     while True:
         port = get_random_port()
         try:
+            # for < 2.92 support (debugpy has problems when using bpy.app.binary_path_python)
+            # https://github.com/microsoft/debugpy/issues/1330
+            debugpy.configure(python=str(python_path))
             debugpy.listen(("localhost", port))
             break
         except OSError:

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -4,7 +4,10 @@ import addon_utils
 from pathlib import Path
 import platform
 
-python_path = Path(sys.executable)
+# binary_path_python was removed in blender 2.92
+# but it is the most reliable way of getting python path for older versions
+# https://github.com/JacquesLucke/blender_vscode/issues/80
+python_path = Path(getattr(bpy.app, "binary_path_python", sys.executable))
 blender_path = Path(bpy.app.binary_path)
 blender_directory = blender_path.parent
 

--- a/pythonFiles/include/blender_vscode/installation.py
+++ b/pythonFiles/include/blender_vscode/installation.py
@@ -40,7 +40,9 @@ def ensure_package_is_installed(name):
 
 def install_package(name):
     target = get_package_install_directory()
-    subprocess.run([str(python_path), "-m", "pip", "install", name, "--target", target], cwd=cwd_for_subprocesses)
+    command = [str(python_path), "-m", "pip", "install", name, "--target", target]
+    print("Execute: ", " ".join(command))
+    subprocess.run(command, cwd=cwd_for_subprocesses)
 
     if not module_can_be_imported(name):
         handle_fatal_error(f"could not install {name}")
@@ -49,7 +51,9 @@ def install_package(name):
 def install_pip():
     # try ensurepip before get-pip.py
     if module_can_be_imported("ensurepip"):
-        subprocess.run([str(python_path), "-m", "ensurepip", "--upgrade"], cwd=cwd_for_subprocesses)
+        command = [str(python_path), "-m", "ensurepip", "--upgrade"]
+        print("Execute: ", " ".join(command))
+        subprocess.run(command, cwd=cwd_for_subprocesses)
         return
     # pip can not necessarily be imported into Blender after this
     get_pip_path = Path(__file__).parent / "external" / "get-pip.py"

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -2,6 +2,7 @@ import os
 import sys
 import traceback
 from pathlib import Path
+from typing import List
 
 import bpy
 
@@ -11,7 +12,7 @@ from .environment import addon_directories
 from .utils import is_addon_legacy
 
 
-def setup_addon_links(addons_to_load: list[AddonInfo]):
+def setup_addon_links(addons_to_load: List[AddonInfo]):
 
     path_mappings = []
 
@@ -44,7 +45,7 @@ def get_user_addon_directory(source_path: Path):
         return Path(bpy.utils.user_resource("EXTENSIONS", path="user_default"))
 
 
-def load(addons_to_load: list[AddonInfo]):
+def load(addons_to_load: List[AddonInfo]):
     for addon_info in addons_to_load:
         if is_addon_legacy(Path(addon_info.load_dir)):
             bpy.ops.preferences.addon_refresh()


### PR DESCRIPTION
Blender 2.,80, 2.91, 2.93 failed to install because of wrong python path.

Most likely fixes #99 #93 #80 #31

- improved finding python path for older versions
- improved typehints to be compatible with python 3.7
- added log for pip call
- fixed debugpy issue when `sys.executable` is not pointing to python what causes timeout 

Tested in basic way with different versions:
```
blender-2.80-windows64
blender-2.83.20-windows-x64
blender-2.90.1-windows64
blender-2.93.18-windows-x64
blender-3.0
blender-3.3.21-windows-x64
blender-3.5.1
blender-3.6.14-windows-x64
blender-4.2.0-windows-x64
```

can be squashed, just remember to iclude sensible merge message.