### PR TITLE
Fix pip installation issues when blender is installed system wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Changed
+- Fix most of the user reported permission denied errors by changing python packages directory:
+  - Instead of installing to system python interpreter (`.\blender-4.2.0-windows-x64\4.2\python\Lib\site-packages` )
+  - Install to local blender modules `%appdata%\Blender Foundation\Blender\4.2\scripts\modules` (path indicated by `bpy.utils.user_resource("SCRIPTS", path="modules")`).
+  - Existing installations will work fine, it is not a breaking change
+
+### Deprecated
+- setting `blender.allowModifyExternalPython` is now deprecated.
+
+### Fixed
+- Pinned requests to version 2.29 to maintain compatibility with blender 2.80
+
 ## [0.0.21] - 2024-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The preferred way to insert this comment is to execute the `Blender: Set Script 
 
 - Make sure you use the newest version of VS Code.
 - Use the latest Blender version from https://www.blender.org/download/.
-- Check [CHANGELOG](./CHANGELOG.md) and check for breaking changes.
+- Check [CHANGELOG](./CHANGELOG.md) for breaking changes.
 - Search Issues for similar problems.
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -37,11 +37,6 @@ For that it is important that you have an internet connection.
 Once Blender is started, you can use the Addon in Blender.
 Debugging should work now.
 
-If the selected Blender executable does not use its own Python version, no packages will be installed by default.
-This is to make sure that the extension does not interfere with another package manager.
-You can either install the modules listed in the error message manually, or allow the extension to install the modules itself.
-To do that, the `blender.allowModifyExternalPython` [setting](https://code.visualstudio.com/docs/getstarted/settings) has to be checked in VS Code.
-
 ### How can I reload my addon in Blender?
 
 Execute the `Blender: Reload Addons` command.
@@ -87,8 +82,9 @@ The preferred way to insert this comment is to execute the `Blender: Set Script 
 ## Troubleshooting
 
 - Make sure you use the newest version of VS Code.
-- Use the latest Blender version from https://builder.blender.org/.
-- If your Blender does not use its own Python version, enable `blender.allowModifyExternalPython` or install the packages in the error message manually (currently `debugpy`, `flask` and `requests` are required).
+- Use the latest Blender version from https://www.blender.org/download/.
+- Check [CHANGELOG](./CHANGELOG.md) and check for breaking changes.
+- Search Issues for similar problems.
 
 ## Status
 

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
             "type": "boolean",
             "scope": "application",
             "default": false,
-            "description": "Allow automatically installing modules in Python distributions outside of Blender."
+            "description": "**Deprecated** Modules are now installed to `bpy.utils.user_resource(\"SCRIPTS\", path=\"modules\")`.\n Allow automatically installing modules in Python distributions outside of Blender."
           },
           "blender.addon.reloadOnSave": {
             "type": "boolean",

--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -12,13 +12,14 @@ class AddonInfo:
     module_name: str
 
 
-def startup(editor_address, addons_to_load: List[AddonInfo], allow_modify_external_python):
+def startup(editor_address, addons_to_load: List[AddonInfo]):
     if bpy.app.version < (2, 80, 34):
         handle_fatal_error("Please use a newer version of Blender")
 
     from . import installation
 
-    installation.ensure_packages_are_installed(["debugpy", "flask", "requests"], allow_modify_external_python)
+    # blender 2.80 'ssl' module is compiled with 'OpenSSL 1.1.0h' what breaks with requests >2.29.0
+    installation.ensure_packages_are_installed(["debugpy", "requests<=2.29.0", "flask"])
 
     from . import load_addons
 

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -11,12 +11,6 @@ python_path = Path(getattr(bpy.app, "binary_path_python", sys.executable))
 blender_path = Path(bpy.app.binary_path)
 blender_directory = blender_path.parent
 
-# Test for MacOS app bundles
-if platform.system() == "Darwin":
-    use_own_python = blender_directory.parent in python_path.parents
-else:
-    use_own_python = blender_directory in python_path.parents
-
 version = bpy.app.version
 scripts_folder = blender_path.parent / f"{version[0]}.{version[1]}" / "scripts"
 addon_directories = tuple(map(Path, addon_utils.paths()))

--- a/pythonFiles/include/blender_vscode/installation.py
+++ b/pythonFiles/include/blender_vscode/installation.py
@@ -1,6 +1,4 @@
-import os
 import sys
-import textwrap
 import subprocess
 
 import bpy
@@ -10,7 +8,7 @@ from pathlib import Path
 from . import handle_fatal_error
 from .environment import python_path
 
-cwd_for_subprocesses = python_path.parent
+_CWD_FOR_SUBPROCESSES = python_path.parent
 
 
 def ensure_packages_are_installed(package_names):
@@ -43,7 +41,7 @@ def install_package(name: str):
     target = get_package_install_directory()
     command = [str(python_path), "-m", "pip", "install", name, "--target", target]
     print("Execute: ", " ".join(command))
-    subprocess.run(command, cwd=cwd_for_subprocesses)
+    subprocess.run(command, cwd=_CWD_FOR_SUBPROCESSES)
 
     if not module_can_be_imported(name):
         handle_fatal_error(f"could not install {name}")
@@ -54,11 +52,11 @@ def install_pip():
     if module_can_be_imported("ensurepip"):
         command = [str(python_path), "-m", "ensurepip", "--upgrade"]
         print("Execute: ", " ".join(command))
-        subprocess.run(command, cwd=cwd_for_subprocesses)
+        subprocess.run(command, cwd=_CWD_FOR_SUBPROCESSES)
         return
     # pip can not necessarily be imported into Blender after this
     get_pip_path = Path(__file__).parent / "external" / "get-pip.py"
-    subprocess.run([str(python_path), str(get_pip_path)], cwd=cwd_for_subprocesses)
+    subprocess.run([str(python_path), str(get_pip_path)], cwd=_CWD_FOR_SUBPROCESSES)
 
 
 def get_package_install_directory() -> str:

--- a/pythonFiles/include/blender_vscode/installation.py
+++ b/pythonFiles/include/blender_vscode/installation.py
@@ -2,7 +2,11 @@ import os
 import sys
 import textwrap
 import subprocess
+
+import bpy
+
 from pathlib import Path
+
 from . import handle_fatal_error
 from .environment import python_path, use_own_python
 
@@ -57,11 +61,13 @@ def install_pip():
 
 
 def get_package_install_directory():
-    for path in sys.path:
-        if os.path.basename(path) in ("dist-packages", "site-packages"):
-            return path
-
-    handle_fatal_error("Don't know where to install packages. Please make a bug report.")
+    # user modules loaded are loaded by default by blender from this path
+    # https://docs.blender.org/manual/en/4.2/editors/preferences/file_paths.html#script-directories
+    modules_path = bpy.utils.user_resource("SCRIPTS", path="modules")
+    if modules_path not in sys.path:
+        # if the path does not exist blender will not load it, usually occurs in fresh install
+        sys.path.append(modules_path)
+    return modules_path
 
 
 def module_can_be_imported(name):

--- a/pythonFiles/include/blender_vscode/installation.py
+++ b/pythonFiles/include/blender_vscode/installation.py
@@ -49,11 +49,6 @@ def install_package(name: str):
         handle_fatal_error(f"could not install {name}")
 
 
-def _strip_pip_version(name: str) -> str:
-    name_strip_comparison_sign = name.replace(">", "=").replace("<", "=")
-    return name_strip_comparison_sign.split("=")[0]
-
-
 def install_pip():
     # try ensurepip before get-pip.py
     if module_can_be_imported("ensurepip"):
@@ -82,3 +77,8 @@ def module_can_be_imported(name: str):
         return True
     except ModuleNotFoundError:
         return False
+
+
+def _strip_pip_version(name: str) -> str:
+    name_strip_comparison_sign = name.replace(">", "=").replace("<", "=")
+    return name_strip_comparison_sign.split("=")[0]

--- a/pythonFiles/launch.py
+++ b/pythonFiles/launch.py
@@ -26,7 +26,6 @@ try:
     blender_vscode.startup(
         editor_address=f"http://localhost:{os.environ['EDITOR_PORT']}",
         addons_to_load=addons_to_load,
-        allow_modify_external_python=os.environ["ALLOW_MODIFY_EXTERNAL_PYTHON"] == "yes",
     )
 except Exception as e:
     if type(e) is not SystemExit:

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -195,7 +195,6 @@ async function getBlenderLaunchEnv() {
     return {
         ADDONS_TO_LOAD: JSON.stringify(loadDirsWithNames),
         EDITOR_PORT: getServerPort().toString(),
-        ALLOW_MODIFY_EXTERNAL_PYTHON: <boolean>config.get('allowModifyExternalPython') ? 'yes' : 'no',
         ...<object>config.get("environmentVariables", {}),
     };
 }


### PR DESCRIPTION
Install dependencies in known, user owned location instead of random python interpreter (usually owned by blender). 

- Current behaviour: installs to `.\blender-4.2.0-windows-x64\4.2\python\Lib\site-packages` 
- New behaviour: installs to `%appdata%\Blender Foundation\Blender\4.2\scripts\modules` (path indicated by `bpy.utils.user_resource("SCRIPTS", path="modules")`).
- Additionally pin dependency for compability with python 3.7 (`requests<=2.29.0`)

Reference: https://docs.blender.org/manual/en/4.2/editors/preferences/file_paths.html#script-directories

Pros:
- does not break existing setups
- This should fix any error related to `PermissionError: [Errno 13]` (windows) for system wide installations of blender.
- this can potentially solve multiple issues: 
  - #173 #169 #105 #99 (probably) #94 #93 #73 (already solved) #70 #37 (maybe) #31
- `pip install ensurepip` has `--upgrade` flag specified what might periodically cause permission denied error 

This kind of error is usually fixed by manually running (or similar):
```
.\blender-4.2.0-windows-x64\4.2\python\bin\python.exe -m pip install flask --target .\blender-4.2.0-windows-x64\4.2\python\Lib\site-packages
```
This change does not break existing user setup: the `pip install` is called only when "test import" fails.
It is also fine to have some packages in old place and some packages in new dir

Cons:
- is it breaking change? TODO Specify example. I did not find any breaking corner cases.

TODOs:
- [x] verify blender 2.8 compability (waits for #174) - ok
- [x] verify 4.2 compability - ok 
- [x] verify the change on bigger project and try to find issues - tested on ImagePaste and other smaller addons 
- [x] verify load order from `sys.path` does not mess with debugging - seems fine
- [x] ensure if reinstalling packages does not throw an error (executing pip install command again). This is very unlikely, but I want to be sure. - ok
- [x] depracate `blender.allowModifyExternalPython`
- [x] old blender installation (2.80) start to have problem with newest dependencies - 
  - pin requests to 2.29.0 to fix blender 2.80

Different design options: 
- try to install in blender python system dir (`site-packages`), if fails, fallback to installation in `modules`
  - a bit more code, but doable. I do not like this idea as it messes with blender default instalation and the modules are very tricky to uninstall.
- Make the required dependencies self contained with VS code extension
  - chellange: blender ships with different python versions. 
- it can be setting or interactive option: `Where do you want to install python dependencies?`

Squash merge after 172 - no particular reason, lets take it one by one.