### PR TITLE
Find default blender executables in system PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 npm-debug.log
 package-lock.json
 __pycache__
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 ### Added
 - Automatically add Blender executables to quick pick window. Search PATH and typical installation folders ([#179](https://github.com/JacquesLucke/blender_vscode/pull/179))
 - If Blender executable does not exist indicate it in quick pick window ([#179](https://github.com/JacquesLucke/blender_vscode/pull/179))
-
-### Changed
 - Support bl_order in auto_load.py (#118)
 - Allow user to develop addon even it is placed in directories like (#172)
   - `\4.2\scripts\addons` -> default dir for addons
   - `\4.2\extensions\blender_org` -> directory indicated by `bpy.context.preferences.extensions.repos` (list of directories) 
 - Remove duplicate links to development (VSCode) directory (#172)
 - Remove broken links in addon and extension dir (#172)
+
+### Changed 
 - Addon_update operator: Check more precisely which module to delete (#175)
 - Formatted all python code with `black -l 120` (#167)
 - Fix most of the user reported permission denied errors by changing python packages directory ([#177](https://github.com/JacquesLucke/blender_vscode/pull/177)):
@@ -25,8 +25,8 @@
 
 ### Fixed
 - Pinned requests to version 2.29 to maintain compatibility with blender 2.80 ([#177](https://github.com/JacquesLucke/blender_vscode/pull/177))
-- "Blender: Run Script" will no longer open read-only file when hitting debug point ([#142](https://github.com/JacquesLucke/blender_vscode/pull/142))
 - Find correct python path for blender 2.92 and before (#174). This partly fixes compatibility with blender 2.80.
+- "Blender: Run Script" will no longer open read-only file when hitting debug point (#142)
 
 ## [0.0.21] - 2024-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+- Automatically add Blender executables to quick pick window. Search PATH and typical installation folders ([#179](https://github.com/JacquesLucke/blender_vscode/pull/179))
+- If Blender executable does not exist indicate it in quick pick window ([#179](https://github.com/JacquesLucke/blender_vscode/pull/179))
+
 ## [0.0.21] - 2024-07-16
 
 ### Added

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -12,7 +12,7 @@ import { getConfig, cancel, runTask } from './utils';
 import { AddonWorkspaceFolder } from './addon_folder';
 import { BlenderWorkspaceFolder } from './blender_folder';
 import { outputChannel } from './extension';
-import { getBlenderInEnvPathWindows } from './blender_executable_windows';
+import { getBlenderWindows } from './blender_executable_windows';
 import { deduplicateSameHardLinks } from './blender_executable_linux';
 
 
@@ -112,7 +112,7 @@ interface BlenderType {
 async function searchBlenderInSystem(): Promise<BlenderPathData[]> {
     const blenders: BlenderPathData[] = [];
     if (process.platform === "win32") {
-        const windowsBlenders = await getBlenderInEnvPathWindows();
+        const windowsBlenders = await getBlenderWindows();
         blenders.push(...windowsBlenders.map(blend_path => ({ path: blend_path, name: "", isDebug: false })))
     }
     const separator = process.platform === "win32" ? ";" : ":"

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -13,8 +13,6 @@ import { AddonWorkspaceFolder } from './addon_folder';
 import { BlenderWorkspaceFolder } from './blender_folder';
 
 
-// const readFileAsync = util.promisify(fs.readFile)
-// const writeFileAsync = util.promisify(fs.writeFile)
 const readdir = util.promisify(fs.readdir)
 const stat = util.promisify(fs.stat)
 
@@ -105,7 +103,6 @@ interface BlenderType {
     setSettings: (item: BlenderPathData) => void;
 }
 
-// those paths will be listed 1 level deep
 const typicalWindowsBlenderFoundationPaths: string[] = [
     path.join(process.env.ProgramFiles ? process.env.ProgramFiles : "C:\\Program Files", "Blender Foundation"),
     path.join(process.env["ProgramFiles(x86)"] ? process.env["ProgramFiles(x86)"] : "C:\\Program Files (x86)", "Blender Foundation"),
@@ -160,7 +157,7 @@ async function getFilteredBlenderPath(type: BlenderType): Promise<BlenderPathDat
         let useCustomName = pathData.name !== '' && pathData.name !== undefined;
         items.push({
             data: async () => pathData,
-            label: useCustomName ? pathData.name : pathData.path,
+            label: useCustomName ? pathData.name : pathData.path
         });
     }
 

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -118,12 +118,18 @@ async function searchBlenderInSystem(): Promise<BlenderPathData[]> {
     if (path_env === undefined) {
         return blenders;
     }
+    const linuxINodes = new Set<number>();
     const exe = process.platform === "win32" ? "blender.exe" : "blender"
     for (const p of path_env) {
         const executable = path.join(p, exe)
         const stats = await stat(executable).catch((err: NodeJS.ErrnoException) => undefined);
         if (stats === undefined) continue;
         if (stats.isFile()) {
+            if (process.platform != "win32" && linuxINodes.has(stats.ino)) {
+                continue // hard link deduplication
+            } else {
+                linuxINodes.add(stats.ino)
+            }
             blenders.push({ path: executable, name: "", isDebug: false })
         }
     }

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -15,7 +15,6 @@ import { getBlenderInEnvPathWindows } from './blender_executable_windows';
 import { outputChannel } from './extension';
 
 
-const readdir = util.promisify(fs.readdir)
 const stat = util.promisify(fs.stat)
 
 export class BlenderExecutable {
@@ -114,7 +113,8 @@ async function searchBlenderInSystem(): Promise<BlenderPathData[]> {
         const windowsBlenders = await getBlenderInEnvPathWindows();
         blenders.push(...windowsBlenders.map(blend_path => ({ path: blend_path, name: "", isDebug: false })))
     }
-    let path_env = process.env.PATH?.split(";");
+    const separator = process.platform === "win32" ? ";" : ":"
+    const path_env = process.env.PATH?.split(separator);
     if (path_env === undefined) {
         return blenders;
     }

--- a/src/blender_executable_linux.ts
+++ b/src/blender_executable_linux.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+
+import { BlenderPathData, stat } from "./blender_executable";
+
+const stat = util.promisify(fs.stat)
+
+export async function deduplicateSameHardLinks(blenderPathsToReduce: BlenderPathData[], removeMissingFiles = true, additionalBlenderPaths: BlenderPathData[] = []) {
+    let missingItem = -1;
+    const additionalBlenderPathsInodes = new Set<number>();
+    for (const item of additionalBlenderPaths) {
+        if (item.linuxInode === undefined) {
+            const stats = await stat(item.path).catch((err: NodeJS.ErrnoException) => undefined);
+            if (stats === undefined) { continue; }
+            item.linuxInode = stats.ino;
+        }
+        additionalBlenderPathsInodes.add(item.linuxInode);
+    }
+
+    const deduplicateHardLinks = new Map<number, BlenderPathData>();
+    for (const item of blenderPathsToReduce) {
+        if (item.linuxInode === undefined) {
+            // try to find missing information
+            const stats = await stat(item.path).catch((err: NodeJS.ErrnoException) => undefined);
+            if (stats === undefined) {
+                if (removeMissingFiles) {
+                    deduplicateHardLinks.set(missingItem, item);
+                    missingItem -= 1;
+                }
+                continue;
+            }
+            item.linuxInode = stats.ino;
+        }
+        if (deduplicateHardLinks.has(item.linuxInode)) continue;
+        if (additionalBlenderPathsInodes.has(item.linuxInode)) continue;
+        deduplicateHardLinks.set(item.linuxInode, item);
+    }
+    return Array.from(deduplicateHardLinks.values());
+}

--- a/src/blender_executable_linux.ts
+++ b/src/blender_executable_linux.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
+import * as util from 'util';
 
-import { BlenderPathData, stat } from "./blender_executable";
+import { BlenderPathData } from "./blender_executable";
 
 const stat = util.promisify(fs.stat)
 

--- a/src/blender_executable_windows.ts
+++ b/src/blender_executable_windows.ts
@@ -27,7 +27,7 @@ const typicalWindowsBlenderFoundationPaths: string[] = [
 ]
 
 
-export async function getBlenderInEnvPathWindows(): Promise<string[]> {
+export async function getBlenderWindows(): Promise<string[]> {
     let blenders: string[] = [];
     let dirs_to_check: string[] = []
     for (const typicalPath of typicalWindowsBlenderFoundationPaths) {

--- a/src/blender_executable_windows.ts
+++ b/src/blender_executable_windows.ts
@@ -1,0 +1,48 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as util from 'util';
+
+
+const readdir = util.promisify(fs.readdir)
+const stat = util.promisify(fs.stat)
+
+
+async function getDirectories(path_: string): Promise<string[]> {
+    let filesAndDirectories = await readdir(path_);
+
+    let directories: string[] = [];
+    await Promise.all(
+        filesAndDirectories.map(async name => {
+            const stats = await stat(path.join(path_, name));
+            if (stats.isDirectory()) directories.push(name);
+        })
+    );
+    return directories;
+}
+
+// todo read from registry Blender installation path
+const typicalWindowsBlenderFoundationPaths: string[] = [
+    path.join(process.env.ProgramFiles || "C:\\Program Files", "Blender Foundation"),
+    path.join(process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)", "Blender Foundation"),
+]
+
+
+export async function getBlenderInEnvPathWindows(): Promise<string[]> {
+    let blenders: string[] = [];
+    let dirs_to_check: string[] = []
+    for (const typicalPath of typicalWindowsBlenderFoundationPaths) {
+        const dirs: string[] = await getDirectories(typicalPath).catch((err: NodeJS.ErrnoException) => []);
+        dirs_to_check.push(...dirs.map((dir: string) => path.join(typicalPath, dir)))
+    }
+
+    const exe = "blender.exe";
+    for (const p of dirs_to_check) {
+        const executable = path.join(p, exe)
+        const stats = await stat(executable).catch((err: NodeJS.ErrnoException) => undefined);
+        if (stats === undefined) continue;
+        if (stats.isFile()) {
+            blenders.push(executable)
+        }
+    }
+    return blenders;
+}

--- a/src/scripts.ts
+++ b/src/scripts.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { templateFilesDir } from './paths';
 import { RunningBlenders } from './communication';
-import { letUserPickItem } from './select_utils';
+import { letUserPickItem, PickItem } from './select_utils';
 import { getAreaTypeItems } from './data_loader';
 import { getConfig, cancel, addFolderToWorkspace, getRandomString, pathExists, copyFile } from './utils';
 
@@ -81,7 +81,7 @@ async function createNewScriptAtPath(filePath: string) {
     await copyFile(defaultScriptPath, filePath);
 }
 
-interface ScriptFolderData {
+export interface ScriptFolderData {
     path: string;
     name: string;
 }
@@ -89,7 +89,7 @@ interface ScriptFolderData {
 async function getFolderForScripts() {
     let scriptFolders = getStoredScriptFolders();
 
-    let items = [];
+    let items: PickItem[] = [];
     for (let folderData of scriptFolders) {
         let useCustomName = folderData.name !== '';
         items.push({

--- a/src/select_utils.ts
+++ b/src/select_utils.ts
@@ -1,14 +1,15 @@
 import * as vscode from 'vscode';
 import { cancel } from './utils';
+import { QuickPickItem } from 'vscode';
+import { BlenderPathData } from './blender_executable';
 
-export interface PickItem {
-    data?: any;
+export interface PickItem extends QuickPickItem {
+    data?: any | (() => Promise<BlenderPathData>),
     label: string;
     description?: string;
     detail?: string;
 }
-
-export async function letUserPickItem(items: PickItem[], placeholder: undefined | string = undefined) : Promise<PickItem> {
+export async function letUserPickItem(items: PickItem[], placeholder: undefined | string = undefined): Promise<PickItem> {
     let quickPick = vscode.window.createQuickPick();
     quickPick.items = items;
     quickPick.placeholder = placeholder;


### PR DESCRIPTION
This PR adds best effort approach to find existing blender installations:
- look at system env PATH and look for bledner executables
- And typical windows locations (as they are not added to path.)
- Prefer paths displayed in user settings
- blender.exe paths are deduplicated. paths in user settings are preffered.
- If Blender executable does not exist indicate it in quick pick window 

Screeshot: The system installation blender was added to list by this feature.
![image](https://github.com/user-attachments/assets/824052c3-49e4-45ae-adbb-2bf6b59b950b)

TODOs:
- listed directories seem to be cached by VScode or system. How does it work and can we rely on this cache?
- [x] windows deduplicate the same path but with lower/upper case, ex `C:\` vs `c:\`
- check for "typical install paths" on 
  - [x] Windows - 
    - [x] program files - done (simple implementation), blender install path can be read from registry (not implemented)
    - [x] steam installation - will not do in this patch, possible but pretty messy to support, see come snippets below
    - [x] store installaion - it might NOT be possible to support. Path `%USERPROFILE%\AppData\Local\Microsoft\WindowsApps` contains only `blender-launcher.exe` and `C:\Program Files\WindowsApps` has no read rights.
  - [x] linux- Apt, snap, flatpack, `~/.bin`,  `/bin`, `/opt`, `/usr/bin`? Those should be already in path
    - [x] deduplicate hard links
    - [x] deduplicate hard links in this situation: user has in settings `/bin/blender` and `searchBlenderInSystem` found `/usr/bin/blender`
    - snap is part of PATH, it should just work `/snap/bin/blender`. Snap started running without window top bar on my setup...
  - [ ] macOs - help wanted!

Those open TODOs are now blockers, but would be nice to test.

Cons:
- causes 1seconds slowdown on first run. I assume system is caching stating files.
- is it going to work in weird cases like blender is on network attached drive?

Snippets for searching blender in steam directories on windows:
```
const typicalSteamConfig = "C:\\Program Files (x85)\\Steam\\steamapps\\libraryfolders.vdf"
// hkey = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\WOW6431Node\Valve\Steam")
// steam_path = winreg.QueryValueEx(hkey, "InstallPath")
// C:\Users\grzel>reg query HKLM\SOFTWARE\WOW6431Node\Valve\Steam /v InstallPath /t REG_SZ
// HKEY_LOCAL_MACHINE\SOFTWARE\WOW6431Node\Valve\Steam
//     InstallPath    REG_SZ    C:\Program Files (x85)\Steam
// End of search: 0 match(es) found.
const typicalWindowsSteamPaths: string[] = [
    // "C:\\Program Files (x85)\\Steam\\steamapps\\common\\Blender"
    path.join(process.env.ProgramFiles || "C:\\Program Files", "Steam", "steamapps", "common", "Blender", "blender.exe"),
    path.join(process.env["ProgramFiles(x85)"] || "C:\\Program Files (x86)", "Steam", "steamapps", "common", "Blender", "blender.exe"),
]
```
