### PR TITLE
Support running `Blender: Start` with single button 🔥🔥🔥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@
 
 - Starting Blender with C and Python debugger.
 - Pin Werkzeug library to avoid crash when opening add-ons in user-preferences ([#191](https://github.com/JacquesLucke/blender_vscode/pull/191)).
->>>>>>> jack/master
 
 ### Added
 ## [0.0.23] - 2024-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- Run `Blender: Start` using single button by adding snippet to `keybindings.json`. Other Commands (like `Blender: Build and Start`) are not supported.
+```json
+{
+    "key": "ctrl+h",
+    "command": "blender.start",
+    "args": {
+        "path": "/path/to/blender.exe"
+        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+    }
+}
+```
+
 ## [0.0.23] - 2024-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   "key": "ctrl+h",
   "command": "blender.start",
   "args": {
-    "blenderExecutable": { // optional, same format as blender.executables
+    "blenderExecutable": { // optional, same format as item in blender.executables
       "path": "C:\\...\\blender.exe" // optional, if missing user will be prompted to choose blender.exe
     }
     // define command line arguments in setting blender.additionalArguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,16 @@
 
 ### Added
 
-- Run `Blender: Start` using single button by adding snippet to `keybindings.json`. Other Commands (like `Blender: Build and Start`) are not supported.
+- Run `Blender: Start` using single button by adding snippet to `keybindings.json`. Other Commands (like `Blender: Build and Start`) are not supported ([#199](https://github.com/JacquesLucke/blender_vscode/pull/199)).
 ```json
 {
-    "key": "ctrl+h",
-    "command": "blender.start",
-    "args": {
-        "path": "/path/to/blender.exe"
-        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+  "key": "ctrl+h",
+  "command": "blender.start",
+  "args": {
+    "blenderExecutable": { // optional, same format as blender.executables
+      "path": "C:\\...\\blender.exe" // optional, if missing user will be prompted to choose blender.exe
     }
+    // define command line arguments in setting blender.additionalArguments
 }
 ```
 - You can now configure VS code internal log level using [`blender.addon.logLevel`](vscode://settings/blender.addon.logLevel) ([#198](https://github.com/JacquesLucke/blender_vscode/pull/198))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@
 - Starting Blender with C and Python debugger.
 - Pin Werkzeug library to avoid crash when opening add-ons in user-preferences ([#191](https://github.com/JacquesLucke/blender_vscode/pull/191)).
 
-### Added
 ## [0.0.23] - 2024-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
 "key": "ctrl+h",
 "command": "blender.start",
 "args": {
-  "blenderExecutable": { // optional, same format as item in blender.executables
-    "path": "C:\\...\\blender.exe" // optional, if missing user will be prompted to choose blender.exe
+  "blenderExecutable": { // optional, if missing user will be prompted to choose blender.exe
+    "path": "C:\\...\\blender.exe"
   }
-  // define command line arguments in setting blender.additionalArguments
+  // define command line arguments in **settings** blender.additionalArguments (not here!!)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
 "key": "ctrl+h",
 "command": "blender.start",
 "args": {
-  "blenderExecutable": { // optional, same format as blender.executables
+  "blenderExecutable": { // optional, same format as item in blender.executables
     "path": "C:\\...\\blender.exe" // optional, if missing user will be prompted to choose blender.exe
   }
   // define command line arguments in setting blender.additionalArguments

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ Environment Variables:
 
 Use VS Code feature [Multi-root Workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces). Each folder in workspace is treated as addon root.
 
+### How to start Blender with shortcut?
+
+You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
+```json
+{
+    "key": "ctrl+h",
+    "command": "blender.start",
+    "args": {
+        "path": "/path/to/blender.exe"
+        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+    }
+}
+```
+
 ## Script Tools
 
 When I say "script" I mean a piece of Python code that runs in Blender but is not an addon.
@@ -130,16 +144,13 @@ The new script file already contains a little bit of code to make it easier to g
 First you have to start a Blender instance by executing the `Blender: Start` command.
 To execute the script in all Blender instances that have been started this way, execute the `Blender: Run Script` command.
 
-You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
+You can assign a shortcut to `Blender: Run Script` by editing `keybindings.json`:
 ```json
-{
-    "key": "ctrl+h",
-    "command": "blender.start",
-    "args": {
-        "path": "/path/to/blender.exe"
-        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
-    }
-}
+  {
+    "key": "ctrl+shift+enter",
+    "command": "blender.runScript",
+    "when": "editorLangId == 'python'"
+  }
 ```
 
 ### How can I change the context the script runs in?

--- a/README.md
+++ b/README.md
@@ -118,12 +118,13 @@ In rare cases debugging with VS Code can crash Blender (ex. https://github.com/J
 You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
 ```json
 {
-    "key": "ctrl+h",
-    "command": "blender.start",
-    "args": {
-        "path": "/path/to/blender.exe"
-        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
-    }
+"key": "ctrl+h",
+"command": "blender.start",
+"args": {
+  "blenderExecutable": { // optional, same format as blender.executables
+    "path": "C:\\...\\blender.exe" // optional, if missing user will be prompted to choose blender.exe
+  }
+  // define command line arguments in setting blender.additionalArguments
 }
 ```
 
@@ -153,15 +154,6 @@ The new script file already contains a little bit of code to make it easier to g
 
 First you have to start a Blender instance by executing the `Blender: Start` command in VS Code's Command Palette.
 To execute the script in all Blender instances that have been started this way, execute the `Blender: Run Script` command.
-
-You can assign a shortcut to `Blender: Run Script` by editing `keybindings.json`:
-```json
-  {
-    "key": "ctrl+shift+enter",
-    "command": "blender.runScript",
-    "when": "editorLangId == 'python'"
-  }
-```
 
 ### How can I change the context the script runs in?
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ The new script file already contains a little bit of code to make it easier to g
 First you have to start a Blender instance by executing the `Blender: Start` command.
 To execute the script in all Blender instances that have been started this way, execute the `Blender: Run Script` command.
 
+You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
+```json
+{
+    "key": "ctrl+h",
+    "command": "blender.start",
+    "args": {
+        "path": "/path/to/blender.exe"
+        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+    }
+}
+```
+
 ### How can I change the context the script runs in?
 
 Currently the support for this is very basic, but still useful.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onDebug",
     "onCommand:blender.start",
     "onCommand:blender.stop",
     "onCommand:blender.build",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "Other"
   ],
   "activationEvents": [
-    "onDebug",
     "onCommand:blender.start",
     "onCommand:blender.stop",
     "onCommand:blender.build",

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -45,9 +45,13 @@ export class BlenderExecutable {
         return new BlenderExecutable(data);
     }
 
-    public static async LaunchAny(blend_filepaths?: string[]) {
-        const executable = await this.GetAny();
-        if (blend_filepaths === undefined) {
+    public static async LaunchAnyInteractive(blend_filepaths?: string[]) {
+        const executable = await this.GetAnyInteractive();
+        await this.LaunchAny(executable, blend_filepaths)
+    }
+
+    public static async LaunchAny(executable: BlenderExecutable, blend_filepaths?: string[]) {
+        if (blend_filepaths === undefined || !blend_filepaths.length) {
             await executable.launch();
             return;
         }
@@ -56,9 +60,13 @@ export class BlenderExecutable {
         }
     }
 
-    public static async LaunchDebug(folder: BlenderWorkspaceFolder, blend_filepaths?: string[]) {
-        const executable = await this.GetAny();
-        if (blend_filepaths === undefined) {
+    public static async LaunchDebugInteractive(folder: BlenderWorkspaceFolder, blend_filepaths?: string[]) {
+        const executable = await this.GetAnyInteractive();
+        await this.LaunchDebug(executable, folder, blend_filepaths)
+    }
+
+    public static async LaunchDebug(executable: BlenderExecutable, folder: BlenderWorkspaceFolder, blend_filepaths?: string[]) {
+        if (blend_filepaths === undefined || !blend_filepaths.length) {
             await executable.launchDebug(folder);
             return;
         }

--- a/src/blender_folder.ts
+++ b/src/blender_folder.ts
@@ -57,7 +57,7 @@ export class BlenderWorkspaceFolder {
             args.push(part);
         }
 
-        let blender = await BlenderExecutable.GetAny();
+        let blender = await BlenderExecutable.GetAnyInteractive();
         await blender.launchWithCustomArgs('build api docs', args);
 
         let execution = new vscode.ProcessExecution('sphinx-build', [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { handleCommandErrors, handleCommandErrorsWithArgs, handleFileExplorerCommandErrors } from './utils';
+import { handleCommandErrors, handleCommandWithArgsErrors, handleFileExplorerCommandErrors } from './utils';
 import { COMMAND_newAddon } from './new_addon';
 import { COMMAND_newOperator } from './new_operator';
 import { AddonWorkspaceFolder } from './addon_folder';
@@ -50,7 +50,7 @@ export function activate(context: vscode.ExtensionContext) {
     let disposables = [
         vscode.workspace.onDidSaveTextDocument(HANDLER_updateOnSave),
     ];
-    const startCom = vscode.commands.registerCommand('blender.start', handleCommandErrorsWithArgs(COMMAND_start));
+    const startCom = vscode.commands.registerCommand('blender.start', handleCommandWithArgsErrors(COMMAND_start));
     disposables.push(startCom);
 
     for (const [identifier, func] of commands) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,21 @@ export function handleErrors(func: () => Promise<void>) {
     };
 }
 
+export function handleErrorsWithArgs(func: (args: any) => Promise<void>) {
+    return async (args: any) => {
+        try {
+            await func(args);
+        }
+        catch (err: any) {
+            if (err instanceof Error) {
+                if (err.message !== CANCEL) {
+                    vscode.window.showErrorMessage(err.message);
+                }
+            }
+        }
+    };
+}
+
 export function getRandomString(length: number = 10) {
     return crypto.randomBytes(length).toString('hex').substring(0, length);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,21 @@ export function getAnyWorkspaceFolder() {
     return folders[0];
 }
 
+export function handleCommandErrorsWithArgs(func: (args: any) => Promise<void>) {
+    return async (args: any) => {
+        try {
+            await func(args);
+        }
+        catch (err: any) {
+            if (err instanceof Error) {
+                if (err.message !== CANCEL) {
+                    vscode.window.showErrorMessage(err.message);
+                }
+            }
+        }
+    };
+}
+
 function handleErrors(func: (...args: any[]) => Promise<void>, ...args: any[]) {
     return async () => {
         try {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function getAnyWorkspaceFolder() {
     return folders[0];
 }
 
-export function handleCommandErrorsWithArgs(func: (args: any) => Promise<void>) {
+export function handleCommandWithArgsErrors(func: (args: any) => Promise<void>) {
     return async (args: any) => {
         try {
             await func(args);


### PR DESCRIPTION
This is low effor support for running blender with one button - it was surprisingly easy to support keybindings. 
This is not ideal, but the goal was to have something useful quickly. Thats all I can deliver for now.

### Other good option, that require dedicated support 

####  `launch.json` support - not implemented 

See example usage of debug: 
https://github.com/microsoft/vscode-python-debugger/blob/main/src/extension/extensionInit.ts#L156

```
vscode.debug.registerDebugAdapterTrackerFactory
```

#### `tasks.json` support - not implemented

Tasks docs: https://code.visualstudio.com/docs/editor/tasks#_customizing-autodetected-tasks
```
tasks.registerTaskProvider
```

Tasks have option to pass `args` but it works completely different from keybinding - I did not have time to write a complete provider (first tried in #102).

References #102 #82 #114.

Ready to squash merge.

Tested with win 11, vs code 1.97.2, blender 2.8, 4.4 and various keybinding config.