### PR TITLE
Support running `Blender: Run Script` with single button 🔥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- Run `Blender: Start` using single button by adding snippet to `keybindings.json`. Other Commands (like `Blender: Build and Start`) are not supported.
+```json
+{
+    "key": "ctrl+h",
+    "command": "blender.start",
+    "args": {
+        "path": "/path/to/blender.exe"
+        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+    }
+}
+```
+
 ## [0.0.23] - 2024-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@
     }
 }
 ```
+- Improvements for `Blender: Run Script`:
+  - When **no** Blender instances are running, run `Blender: Start` and then immediately run `Blender: Run Script`
+  - When Blender instances are running, do nothing (old behavior)
+  - Specify default `Blender: Start` configuration in settings using `isBlenderRunScriptDefault` in [`blender.executables`](vscode://settings/blender.executables)
+  - Run `Blender: Run Script` using single button by adding snippet to `keybindings.json`. 
+```json
+  {
+    "key": "ctrl+shift+enter",
+    "command": "blender.runScript",
+    "when": "editorLangId == 'python'"
+  }
+```
+
+### Fixed
+
+- `linuxInode` should no longer be saved in settings [`blender.executables`](vscode://settings/blender.executables)
 
 ## [0.0.23] - 2024-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ```
 - Improvements for `Blender: Run Script`:
   - When **no** Blender instances are running, run `Blender: Start` and then immediately run `Blender: Run Script`
-  - When Blender instances are running, do nothing (old behavior)
+  - When Blender instances are running, just run the script on all available instances (old behavior)
   - Specify default `Blender: Start` configuration in settings using `isBlenderRunScriptDefault` in [`blender.executables`](vscode://settings/blender.executables)
   - Run `Blender: Run Script` using single button by adding snippet to `keybindings.json`. 
 ```json

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ Environment Variables:
 
 Use VS Code feature [Multi-root Workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces). Each folder in workspace is treated as addon root.
 
+### How to start Blender with shortcut?
+
+You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
+```json
+{
+    "key": "ctrl+h",
+    "command": "blender.start",
+    "args": {
+        "path": "/path/to/blender.exe"
+        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+    }
+}
+```
+
 ## Script Tools
 
 When I say "script" I mean a piece of Python code that runs in Blender but is not an addon.
@@ -130,16 +144,13 @@ The new script file already contains a little bit of code to make it easier to g
 First you have to start a Blender instance by executing the `Blender: Start` command.
 To execute the script in all Blender instances that have been started this way, execute the `Blender: Run Script` command.
 
-You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
+You can assign a shortcut to `Blender: Run Script` by editing `keybindings.json`:
 ```json
-{
-    "key": "ctrl+h",
-    "command": "blender.start",
-    "args": {
-        "path": "/path/to/blender.exe"
-        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
-    }
-}
+  {
+    "key": "ctrl+shift+enter",
+    "command": "blender.runScript",
+    "when": "editorLangId == 'python'"
+  }
 ```
 
 ### How can I change the context the script runs in?

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ The new script file already contains a little bit of code to make it easier to g
 First you have to start a Blender instance by executing the `Blender: Start` command.
 To execute the script in all Blender instances that have been started this way, execute the `Blender: Run Script` command.
 
+You can assign a shortcut to `Blender: Start` by editing `keybindings.json`:
+```json
+{
+    "key": "ctrl+h",
+    "command": "blender.start",
+    "args": {
+        "path": "/path/to/blender.exe"
+        // "additionalArguments": [], // overrides VS Code settings blender.additionalArguments
+    }
+}
+```
+
 ### How can I change the context the script runs in?
 
 Currently the support for this is very basic, but still useful.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "Other"
   ],
   "activationEvents": [
+    "onDebug",
     "onCommand:blender.start",
     "onCommand:blender.stop",
     "onCommand:blender.build",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "Other"
   ],
   "activationEvents": [
-    "onDebug",
     "onCommand:blender.start",
     "onCommand:blender.stop",
     "onCommand:blender.build",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
                   "type": "boolean",
                   "description": "Is this executable a debug build.",
                   "default": false
+                },
+                "isBlenderRunScriptDefault": {
+                  "type": "boolean",
+                  "description": "Use this settings to automatically start instance when calling `Blender: Run Script` if no blender instances are running. If multiple items have this setting set to true, only first one is used.",
+                  "default": false
                 }
               }
             }

--- a/src/blender_folder.ts
+++ b/src/blender_folder.ts
@@ -57,7 +57,7 @@ export class BlenderWorkspaceFolder {
             args.push(part);
         }
 
-        let blender = await BlenderExecutable.GetAny();
+        let blender = await BlenderExecutable.GetAnyInteractive();
         await blender.launchWithCustomArgs('build api docs', args);
 
         let execution = new vscode.ProcessExecution('sphinx-build', [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,23 +83,23 @@ type StartCommandArguments = {
     path?: string;
 }
 
-async function COMMAND_start(args?: StartCommandArguments) {
+export async function COMMAND_start(args?: StartCommandArguments) {
     // args are used in keybidings
     console.log(args)
     let blenderFolder = await BlenderWorkspaceFolder.Get();
     if (blenderFolder === null) {
         if (args === undefined) {
-            await BlenderExecutable.LaunchAnyInteractive();
+            return await BlenderExecutable.LaunchAnyInteractive();
         } else {
             if (args.path === undefined)
                 throw new Error("args.path is not defined")
             if (args.additionalArguments !== undefined && !Array.isArray(args.additionalArguments))
                 throw new Error("args.additionalArguments must be list")
-            await BlenderExecutable.LaunchAny(args.path, args.additionalArguments);             
+            return await BlenderExecutable.LaunchAny(args.path, args.additionalArguments)
         }
     }
     else {
-        await BlenderExecutable.LaunchDebugInteractive(blenderFolder);
+        return await BlenderExecutable.LaunchDebugInteractive(blenderFolder);
     }
 }
 

--- a/src/python_debugging.ts
+++ b/src/python_debugging.ts
@@ -14,7 +14,7 @@ export async function attachPythonDebuggerToBlender(
     addonPathMappings: AddonPathMapping[]) {
 
     let mappings = await getPythonPathMappings(scriptsFolder, addonPathMappings);
-    attachPythonDebugger(port, justMyCode, mappings);
+    return attachPythonDebugger(port, justMyCode, mappings);
 }
 
 function attachPythonDebugger(port: number, justMyCode: boolean, pathMappings: PathMapping[] = []) {
@@ -30,7 +30,7 @@ function attachPythonDebugger(port: number, justMyCode: boolean, pathMappings: P
 
     outputChannel.appendLine("Python debug configuration: " + JSON.stringify(configuration, undefined, 2));
 
-    vscode.debug.startDebugging(undefined, configuration);
+    return vscode.debug.startDebugging(undefined, configuration);
 }
 
 async function getPythonPathMappings(scriptsFolder: string, addonPathMappings: AddonPathMapping[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,7 +56,7 @@ export function handleErrors(func: () => Promise<void>) {
     };
 }
 
-export function handleErrorsWithArgs(func: (args: any) => Promise<void>) {
+export function handleErrorsWithArgs(func: (args: any) => Promise<void | vscode.TaskExecution>) {
     return async (args: any) => {
         try {
             await func(args);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,21 @@ export function handleErrors(func: () => Promise<void>) {
     };
 }
 
+export function handleErrorsWithArgs(func: (args: any) => Promise<void>) {
+    return async (args: any) => {
+        try {
+            await func(args);
+        }
+        catch (err: any) {
+            if (err instanceof Error) {
+                if (err.message !== CANCEL) {
+                    vscode.window.showErrorMessage(err.message);
+                }
+            }
+        }
+    };
+}
+
 export function getRandomString(length: number = 10) {
     return crypto.randomBytes(length).toString('hex').substring(0, length);
 }


### PR DESCRIPTION
This branch is continuation of #199 but with focus on `Blender: Run Script`. Lets deal with 199 first, here I also made many changes.

- Improvements for `Blender: Run Script`:
  - When **no** Blender instances are running, run `Blender: Start` and then immediately run `Blender: Run Script`
  - When Blender instances are running, just run the script on all available instances (old behavior)
  - Specify default `Blender: Start` configuration in settings using `isBlenderRunScriptDefault` in [`blender.executables`](vscode://settings/blender.executables)
  - Run `Blender: Run Script` using single button by adding snippet to `keybindings.json`. 
```json
  {
    "key": "ctrl+shift+enter",
    "command": "blender.runScript",
    "when": "editorLangId == 'python'"
  }
```