### PR TITLE
Fix #191: improve handling of dependencies

### DIFF
--- a/pythonFiles/include/blender_vscode/__init__.py
+++ b/pythonFiles/include/blender_vscode/__init__.py
@@ -18,8 +18,14 @@ def startup(editor_address, addons_to_load: List[AddonInfo]):
 
     from . import installation
 
-    # blender 2.80 'ssl' module is compiled with 'OpenSSL 1.1.0h' what breaks with requests >2.29.0
-    installation.ensure_packages_are_installed(["debugpy", "requests<=2.29.0", "werkzeug<=3.0.3", "flask<=3.0.3"])
+    installation.ensure_packages_are_installed(
+        [
+            "debugpy",
+            "requests<=2.29.0",  # blender 2.80 'ssl' module is compiled with 'OpenSSL 1.1.0h' what breaks with requests >2.29.0
+            "werkzeug<=3.0.3",
+            "flask<=3.0.3",  # keep flask version pinned until werkzeug and underlying multiprocessing issue is fixed: https://github.com/JacquesLucke/blender_vscode/issues/191
+        ]
+    )
 
     from . import load_addons
 

--- a/pythonFiles/include/blender_vscode/environment.py
+++ b/pythonFiles/include/blender_vscode/environment.py
@@ -4,7 +4,6 @@ import bpy
 import sys
 import addon_utils
 from pathlib import Path
-import platform
 import os
 
 # binary_path_python was removed in blender 2.92

--- a/pythonFiles/include/semver/__about__.py
+++ b/pythonFiles/include/semver/__about__.py
@@ -1,0 +1,37 @@
+"""
+Metadata about semver.
+
+Contains information about semver's version, the implemented version
+of the semver specifictation, author, maintainers, and description.
+
+.. autodata:: __author__
+
+.. autodata:: __description__
+
+.. autodata:: __maintainer__
+
+.. autodata:: __version__
+
+.. autodata:: SEMVER_SPEC_VERSION
+"""
+
+#: Semver version
+__version__ = "3.0.2"
+
+#: Original semver author
+__author__ = "Kostiantyn Rybnikov"
+
+#: Author's email address
+__author_email__ = "k-bx@k-bx.com"
+
+#: Current maintainer
+__maintainer__ = ["Sebastien Celles", "Tom Schraitle"]
+
+#: Maintainer's email address
+__maintainer_email__ = "s.celles@gmail.com"
+
+#: Short description about semver
+__description__ = "Python helper for Semantic Versioning (https://semver.org)"
+
+#: Supported semver specification
+SEMVER_SPEC_VERSION = "2.0.0"

--- a/pythonFiles/include/semver/__init__.py
+++ b/pythonFiles/include/semver/__init__.py
@@ -1,0 +1,72 @@
+"""
+Semver package major release 3.
+
+A Python module for semantic versioning. Simplifies comparing versions.
+"""
+
+from ._deprecated import (
+    bump_build,
+    bump_major,
+    bump_minor,
+    bump_patch,
+    compare,
+    bump_prerelease,
+    finalize_version,
+    format_version,
+    match,
+    max_ver,
+    min_ver,
+    parse,
+    parse_version_info,
+    replace,
+    cmd_bump,
+    cmd_compare,
+    cmd_nextver,
+    cmd_check,
+    createparser,
+    process,
+    main,
+)
+from .version import Version, VersionInfo
+from .__about__ import (
+    __version__,
+    __author__,
+    __maintainer__,
+    __author_email__,
+    __description__,
+    __maintainer_email__,
+    SEMVER_SPEC_VERSION,
+)
+
+__all__ = [
+    "bump_build",
+    "bump_major",
+    "bump_minor",
+    "bump_patch",
+    "compare",
+    "bump_prerelease",
+    "finalize_version",
+    "format_version",
+    "match",
+    "max_ver",
+    "min_ver",
+    "parse",
+    "parse_version_info",
+    "replace",
+    "cmd_bump",
+    "cmd_compare",
+    "cmd_nextver",
+    "cmd_check",
+    "createparser",
+    "process",
+    "main",
+    "Version",
+    "VersionInfo",
+    "__version__",
+    "__author__",
+    "__maintainer__",
+    "__author_email__",
+    "__description__",
+    "__maintainer_email__",
+    "SEMVER_SPEC_VERSION",
+]

--- a/pythonFiles/include/semver/__main__.py
+++ b/pythonFiles/include/semver/__main__.py
@@ -1,0 +1,28 @@
+"""
+Module to support call with :file:`__main__.py`. Used to support the following
+call::
+
+    $ python3 -m semver ...
+
+This makes it also possible to "run" a wheel like in this command::
+
+    $ python3 semver-3*-py3-none-any.whl/semver -h
+
+"""
+import os.path
+import sys
+from typing import List, Optional
+
+from semver import cli
+
+
+def main(cliargs: Optional[List[str]] = None) -> int:
+    if __package__ == "":
+        path = os.path.dirname(os.path.dirname(__file__))
+        sys.path[0:0] = [path]
+
+    return cli.main(cliargs)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/pythonFiles/include/semver/_deprecated.py
+++ b/pythonFiles/include/semver/_deprecated.py
@@ -1,0 +1,410 @@
+"""
+Contains all deprecated functions.
+
+.. autofunction: deprecated
+"""
+import inspect
+import warnings
+from functools import partial, wraps
+from types import FrameType
+from typing import Type, Callable, Optional, cast
+
+from . import cli
+from .version import Version
+from ._types import Decorator, F
+
+
+def deprecated(
+    func: Optional[F] = None,
+    *,
+    replace: Optional[str] = None,
+    version: Optional[str] = None,
+    remove: Optional[str] = None,
+    category: Type[Warning] = DeprecationWarning,
+) -> Decorator:
+    """
+    Decorates a function to output a deprecation warning.
+
+    :param func: the function to decorate
+    :param replace: the function to replace (use the full qualified
+        name like ``semver.version.Version.bump_major``.
+    :param version: the first version when this function was deprecated.
+    :param category: allow you to specify the deprecation warning class
+        of your choice. By default, it's  :class:`DeprecationWarning`, but
+        you can choose :class:`PendingDeprecationWarning` or a custom class.
+    :return: decorated function which is marked as deprecated
+    """
+
+    if func is None:
+        return partial(
+            deprecated,
+            replace=replace,
+            version=version,
+            remove=remove,
+            category=category,
+        )
+
+    @wraps(func)
+    def wrapper(*args, **kwargs) -> Callable[..., F]:
+        msg_list = ["Function 'semver.{f}' is deprecated."]
+
+        if version:
+            msg_list.append("Deprecated since version {v}. ")
+
+        if not remove:
+            msg_list.append("This function will be removed in semver 3.")
+        else:
+            msg_list.append(str(remove))
+
+        if replace:
+            msg_list.append("Use {r!r} instead.")
+        else:
+            msg_list.append("Use the respective 'semver.Version.{r}' instead.")
+
+        f = cast(F, func).__qualname__
+        r = replace or f
+
+        frame = cast(FrameType, cast(FrameType, inspect.currentframe()).f_back)
+
+        msg = " ".join(msg_list)
+        warnings.warn_explicit(
+            msg.format(f=f, r=r, v=version),
+            category=category,
+            filename=inspect.getfile(frame.f_code),
+            lineno=frame.f_lineno,
+        )
+        # As recommended in the Python documentation
+        # https://docs.python.org/3/library/inspect.html#the-interpreter-stack
+        # better remove the interpreter stack:
+        del frame
+        return func(*args, **kwargs)  # type: ignore
+
+    return wrapper
+
+
+@deprecated(
+    version="3.0.0",
+    remove="Still under investigation, see #258.",
+    category=PendingDeprecationWarning,
+)
+def compare(ver1: str, ver2: str) -> int:
+    """
+    Compare two versions strings.
+
+    .. deprecated:: 3.0.0
+       The situation of this function is unclear and it might
+       disappear in the future.
+       If possible, use :meth:`semver.version.Version.compare`.
+       See :gh:`258` for details.
+
+    :param ver1: first version string
+    :param ver2: second version string
+    :return: The return value is negative if ver1 < ver2,
+             zero if ver1 == ver2 and strictly positive if ver1 > ver2
+
+    >>> semver.compare("1.0.0", "2.0.0")
+    -1
+    >>> semver.compare("2.0.0", "1.0.0")
+    1
+    >>> semver.compare("2.0.0", "2.0.0")
+    0
+    """
+    return Version.parse(ver1).compare(ver2)
+
+
+@deprecated(version="2.10.0")
+def parse(version):
+    """
+    Parse version to major, minor, patch, pre-release, build parts.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.parse` instead.
+
+    :param version: version string
+    :return: dictionary with the keys 'build', 'major', 'minor', 'patch',
+             and 'prerelease'. The prerelease or build keys can be None
+             if not provided
+    :rtype: dict
+
+    >>> ver = semver.parse('3.4.5-pre.2+build.4')
+    >>> ver['major']
+    3
+    >>> ver['minor']
+    4
+    >>> ver['patch']
+    5
+    >>> ver['prerelease']
+    'pre.2'
+    >>> ver['build']
+    'build.4'
+    """
+    return Version.parse(version).to_dict()
+
+
+@deprecated(replace="semver.version.Version.parse", version="2.10.0")
+def parse_version_info(version):
+    """
+    Parse version string to a Version instance.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.parse` instead.
+    .. versionadded:: 2.7.2
+       Added :func:`semver.parse_version_info`
+
+    :param version: version string
+    :return: a :class:`VersionInfo` instance
+
+    >>> version_info = semver.Version.parse("3.4.5-pre.2+build.4")
+    >>> version_info.major
+    3
+    >>> version_info.minor
+    4
+    >>> version_info.patch
+    5
+    >>> version_info.prerelease
+    'pre.2'
+    >>> version_info.build
+    'build.4'
+    """
+    return Version.parse(version)
+
+
+@deprecated(version="2.10.0")
+def match(version, match_expr):
+    """
+    Compare two versions strings through a comparison.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.match` instead.
+
+    :param str version: a version string
+    :param str match_expr: operator and version; valid operators are
+          <   smaller than
+          >   greater than
+          >=  greator or equal than
+          <=  smaller or equal than
+          ==  equal
+          !=  not equal
+    :return: True if the expression matches the version, otherwise False
+    :rtype: bool
+
+    >>> semver.match("2.0.0", ">=1.0.0")
+    True
+    >>> semver.match("1.0.0", ">1.0.0")
+    False
+    """
+    ver = Version.parse(version)
+    return ver.match(match_expr)
+
+
+@deprecated(replace="max", version="2.10.2")
+def max_ver(ver1, ver2):
+    """
+    Returns the greater version of two versions strings.
+
+    .. deprecated:: 2.10.2
+       Use :func:`max` instead.
+
+    :param ver1: version string 1
+    :param ver2: version string 2
+    :return: the greater version of the two
+    :rtype: :class:`Version`
+
+    >>> semver.max_ver("1.0.0", "2.0.0")
+    '2.0.0'
+    """
+    return str(max(ver1, ver2, key=Version.parse))
+
+
+@deprecated(replace="min", version="2.10.2")
+def min_ver(ver1, ver2):
+    """
+    Returns the smaller version of two versions strings.
+
+    .. deprecated:: 2.10.2
+       Use Use :func:`min` instead.
+
+    :param ver1: version string 1
+    :param ver2: version string 2
+    :return: the smaller version of the two
+    :rtype: :class:`Version`
+
+    >>> semver.min_ver("1.0.0", "2.0.0")
+    '1.0.0'
+    """
+    return str(min(ver1, ver2, key=Version.parse))
+
+
+@deprecated(replace="str(versionobject)", version="2.10.0")
+def format_version(major, minor, patch, prerelease=None, build=None):
+    """
+    Format a version string according to the Semantic Versioning specification.
+
+    .. deprecated:: 2.10.0
+       Use ``str(Version(VERSION)`` instead.
+
+    :param int major: the required major part of a version
+    :param int minor: the required minor part of a version
+    :param int patch: the required patch part of a version
+    :param str prerelease: the optional prerelease part of a version
+    :param str build: the optional build part of a version
+    :return: the formatted string
+    :rtype: str
+
+    >>> semver.format_version(3, 4, 5, 'pre.2', 'build.4')
+    '3.4.5-pre.2+build.4'
+    """
+    return str(Version(major, minor, patch, prerelease, build))
+
+
+@deprecated(version="2.10.0")
+def bump_major(version):
+    """
+    Raise the major part of the version string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.bump_major` instead.
+
+    :param: version string
+    :return: the raised version string
+    :rtype: str
+
+    >>> semver.bump_major("3.4.5")
+    '4.0.0'
+    """
+    return str(Version.parse(version).bump_major())
+
+
+@deprecated(version="2.10.0")
+def bump_minor(version):
+    """
+    Raise the minor part of the version string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.bump_minor` instead.
+
+    :param: version string
+    :return: the raised version string
+    :rtype: str
+
+    >>> semver.bump_minor("3.4.5")
+    '3.5.0'
+    """
+    return str(Version.parse(version).bump_minor())
+
+
+@deprecated(version="2.10.0")
+def bump_patch(version):
+    """
+    Raise the patch part of the version string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.bump_patch` instead.
+
+    :param: version string
+    :return: the raised version string
+    :rtype: str
+
+    >>> semver.bump_patch("3.4.5")
+    '3.4.6'
+    """
+    return str(Version.parse(version).bump_patch())
+
+
+@deprecated(version="2.10.0")
+def bump_prerelease(version, token="rc"):
+    """
+    Raise the prerelease part of the version string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.bump_prerelease` instead.
+
+    :param version: version string
+    :param token: defaults to 'rc'
+    :return: the raised version string
+    :rtype: str
+
+    >>> semver.bump_prerelease('3.4.5', 'dev')
+    '3.4.5-dev.1'
+    """
+    return str(Version.parse(version).bump_prerelease(token))
+
+
+@deprecated(version="2.10.0")
+def bump_build(version, token="build"):
+    """
+    Raise the build part of the version string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.bump_build` instead.
+
+    :param version: version string
+    :param token: defaults to 'build'
+    :return: the raised version string
+    :rtype: str
+
+    >>> semver.bump_build('3.4.5-rc.1+build.9')
+    '3.4.5-rc.1+build.10'
+    """
+    return str(Version.parse(version).bump_build(token))
+
+
+@deprecated(version="2.10.0")
+def finalize_version(version):
+    """
+    Remove any prerelease and build metadata from the version string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.finalize_version` instead.
+
+    .. versionadded:: 2.7.9
+       Added :func:`finalize_version`
+
+    :param version: version string
+    :return: the finalized version string
+    :rtype: str
+
+    >>> semver.finalize_version('1.2.3-rc.5')
+    '1.2.3'
+    """
+    verinfo = Version.parse(version)
+    return str(verinfo.finalize_version())
+
+
+@deprecated(version="2.10.0")
+def replace(version, **parts):
+    """
+    Replace one or more parts of a version and return the new string.
+
+    .. deprecated:: 2.10.0
+       Use :meth:`~semver.version.Version.replace` instead.
+    .. versionadded:: 2.9.0
+       Added :func:`replace`
+
+    :param version: the version string to replace
+    :param parts: the parts to be updated. Valid keys are:
+      ``major``, ``minor``, ``patch``, ``prerelease``, or ``build``
+    :return: the replaced version string
+    :raises TypeError: if ``parts`` contains invalid keys
+
+    >>> import semver
+    >>> semver.replace("1.2.3", major=2, patch=10)
+    '2.2.10'
+    """
+    return str(Version.parse(version).replace(**parts))
+
+
+# CLI
+cmd_bump = deprecated(cli.cmd_bump, replace="semver.cli.cmd_bump", version="3.0.0")
+cmd_check = deprecated(cli.cmd_check, replace="semver.cli.cmd_check", version="3.0.0")
+cmd_compare = deprecated(
+    cli.cmd_compare, replace="semver.cli.cmd_compare", version="3.0.0"
+)
+cmd_nextver = deprecated(
+    cli.cmd_nextver, replace="semver.cli.cmd_nextver", version="3.0.0"
+)
+createparser = deprecated(
+    cli.createparser, replace="semver.cli.createparser", version="3.0.0"
+)
+process = deprecated(cli.process, replace="semver.cli.process", version="3.0.0")
+main = deprecated(cli.main, replace="semver.cli.main", version="3.0.0")

--- a/pythonFiles/include/semver/_types.py
+++ b/pythonFiles/include/semver/_types.py
@@ -1,0 +1,12 @@
+"""Typing for semver."""
+
+from functools import partial
+from typing import Union, Optional, Tuple, Dict, Iterable, Callable, TypeVar
+
+VersionPart = Union[int, Optional[str]]
+VersionTuple = Tuple[int, int, int, Optional[str], Optional[str]]
+VersionDict = Dict[str, VersionPart]
+VersionIterator = Iterable[VersionPart]
+String = Union[str, bytes]
+F = TypeVar("F", bound=Callable)
+Decorator = Union[Callable[..., F], partial]

--- a/pythonFiles/include/semver/cli.py
+++ b/pythonFiles/include/semver/cli.py
@@ -1,0 +1,174 @@
+"""
+CLI parsing for :command:`pysemver` command.
+
+Each command in :command:`pysemver` is mapped to a ``cmd_`` function.
+The :func:`main <semver.cli.main>` function calls
+:func:`createparser <semver.cli.createparser>` and
+:func:`process <semver.cli.process>` to parse and process
+all the commandline options.
+
+The result of each command is printed on stdout.
+"""
+
+import argparse
+import sys
+from typing import cast, List, Optional
+
+from .version import Version
+from .__about__ import __version__
+
+
+def cmd_bump(args: argparse.Namespace) -> str:
+    """
+    Subcommand: Bumps a version.
+
+    Synopsis: bump <PART> <VERSION>
+    <PART> can be major, minor, patch, prerelease, or build
+
+    :param args: The parsed arguments
+    :return: the new, bumped version
+    """
+    maptable = {
+        "major": "bump_major",
+        "minor": "bump_minor",
+        "patch": "bump_patch",
+        "prerelease": "bump_prerelease",
+        "build": "bump_build",
+    }
+    if args.bump is None:
+        # When bump is called without arguments,
+        # print the help and exit
+        args.parser.parse_args(["bump", "-h"])
+
+    ver = Version.parse(args.version)
+    # get the respective method and call it
+    func = getattr(ver, maptable[cast(str, args.bump)])
+    return str(func())
+
+
+def cmd_check(args: argparse.Namespace) -> None:
+    """
+    Subcommand: Checks if a string is a valid semver version.
+
+    Synopsis: check <VERSION>
+
+    :param args: The parsed arguments
+    """
+    if Version.is_valid(args.version):
+        return None
+    raise ValueError("Invalid version %r" % args.version)
+
+
+def cmd_compare(args: argparse.Namespace) -> str:
+    """
+    Subcommand: Compare two versions.
+
+    Synopsis: compare <VERSION1> <VERSION2>
+
+    :param args: The parsed arguments
+    """
+    ver1 = Version.parse(args.version1)
+    return str(ver1.compare(args.version2))
+
+
+def cmd_nextver(args: argparse.Namespace) -> str:
+    """
+    Subcommand: Determines the next version, taking prereleases into account.
+
+    Synopsis: nextver <VERSION> <PART>
+
+    :param args: The parsed arguments
+    """
+    version = Version.parse(args.version)
+    return str(version.next_version(args.part))
+
+
+def createparser() -> argparse.ArgumentParser:
+    """
+    Create an :class:`argparse.ArgumentParser` instance.
+
+    :return: parser instance
+    """
+    parser = argparse.ArgumentParser(prog=__package__, description=__doc__)
+
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + __version__
+    )
+
+    s = parser.add_subparsers()
+    # create compare subcommand
+    parser_compare = s.add_parser("compare", help="Compare two versions")
+    parser_compare.set_defaults(func=cmd_compare)
+    parser_compare.add_argument("version1", help="First version")
+    parser_compare.add_argument("version2", help="Second version")
+
+    # create bump subcommand
+    parser_bump = s.add_parser("bump", help="Bumps a version")
+    parser_bump.set_defaults(func=cmd_bump)
+    sb = parser_bump.add_subparsers(title="Bump commands", dest="bump")
+
+    # Create subparsers for the bump subparser:
+    for p in (
+        sb.add_parser("major", help="Bump the major part of the version"),
+        sb.add_parser("minor", help="Bump the minor part of the version"),
+        sb.add_parser("patch", help="Bump the patch part of the version"),
+        sb.add_parser("prerelease", help="Bump the prerelease part of the version"),
+        sb.add_parser("build", help="Bump the build part of the version"),
+    ):
+        p.add_argument("version", help="Version to raise")
+
+    # Create the check subcommand
+    parser_check = s.add_parser(
+        "check", help="Checks if a string is a valid semver version"
+    )
+    parser_check.set_defaults(func=cmd_check)
+    parser_check.add_argument("version", help="Version to check")
+
+    # Create the nextver subcommand
+    parser_nextver = s.add_parser(
+        "nextver", help="Determines the next version, taking prereleases into account."
+    )
+    parser_nextver.set_defaults(func=cmd_nextver)
+    parser_nextver.add_argument("version", help="Version to raise")
+    parser_nextver.add_argument(
+        "part", help="One of 'major', 'minor', 'patch', or 'prerelease'"
+    )
+    return parser
+
+
+def process(args: argparse.Namespace) -> str:
+    """
+    Process the input from the CLI.
+
+    :param args: The parsed arguments
+    :param parser: the parser instance
+    :return: result of the selected action
+    """
+    if not hasattr(args, "func"):
+        args.parser.print_help()
+        raise SystemExit()
+
+    # Call the respective function object:
+    return args.func(args)
+
+
+def main(cliargs: Optional[List[str]] = None) -> int:
+    """
+    Entry point for the application script.
+
+    :param list cliargs: Arguments to parse or None (=use :class:`sys.argv`)
+    :return: error code
+    """
+    try:
+        parser = createparser()
+        args = parser.parse_args(args=cliargs)
+        # Save parser instance:
+        args.parser = parser
+        result = process(args)
+        if result is not None:
+            print(result)
+        return 0
+
+    except (ValueError, TypeError) as err:
+        print("ERROR", err, file=sys.stderr)
+        return 2

--- a/pythonFiles/include/semver/version.py
+++ b/pythonFiles/include/semver/version.py
@@ -1,0 +1,742 @@
+"""Version handling by a semver compatible version class."""
+
+import re
+from functools import wraps
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Optional,
+    Pattern,
+    SupportsInt,
+    Tuple,
+    Union,
+    cast,
+    Callable,
+    Collection,
+    Type,
+    TypeVar,
+)
+
+from ._types import (
+    VersionTuple,
+    VersionDict,
+    VersionIterator,
+    String,
+    VersionPart,
+)
+
+# These types are required here because of circular imports
+Comparable = Union["Version", Dict[str, VersionPart], Collection[VersionPart], str]
+Comparator = Callable[["Version", Comparable], bool]
+
+T = TypeVar("T", bound="Version")
+
+
+def _comparator(operator: Comparator) -> Comparator:
+    """Wrap a Version binary op method in a type-check."""
+
+    @wraps(operator)
+    def wrapper(self: "Version", other: Comparable) -> bool:
+        comparable_types = (
+            Version,
+            dict,
+            tuple,
+            list,
+            *String.__args__,  # type: ignore
+        )
+        if not isinstance(other, comparable_types):
+            return NotImplemented
+        return operator(self, other)
+
+    return wrapper
+
+
+def _cmp(a, b):  # TODO: type hints
+    """Return negative if a<b, zero if a==b, positive if a>b."""
+    return (a > b) - (a < b)
+
+
+class Version:
+    """
+    A semver compatible version class.
+
+    See specification at https://semver.org.
+
+    :param major: version when you make incompatible API changes.
+    :param minor: version when you add functionality in a backwards-compatible manner.
+    :param patch: version when you make backwards-compatible bug fixes.
+    :param prerelease: an optional prerelease string
+    :param build: an optional build string
+    """
+
+    __slots__ = ("_major", "_minor", "_patch", "_prerelease", "_build")
+
+    #: The names of the different parts of a version
+    NAMES: ClassVar[Tuple[str, ...]] = tuple([item[1:] for item in __slots__])
+
+    #: Regex for number in a prerelease
+    _LAST_NUMBER: ClassVar[Pattern[str]] = re.compile(r"(?:[^\d]*(\d+)[^\d]*)+")
+    #: Regex template for a semver version
+    _REGEX_TEMPLATE: ClassVar[
+        str
+    ] = r"""
+            ^
+            (?P<major>0|[1-9]\d*)
+            (?:
+                \.
+                (?P<minor>0|[1-9]\d*)
+                (?:
+                    \.
+                    (?P<patch>0|[1-9]\d*)
+                ){opt_patch}
+            ){opt_minor}
+            (?:-(?P<prerelease>
+                (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+                (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
+            ))?
+            (?:\+(?P<build>
+                [0-9a-zA-Z-]+
+                (?:\.[0-9a-zA-Z-]+)*
+            ))?
+            $
+        """
+    #: Regex for a semver version
+    _REGEX: ClassVar[Pattern[str]] = re.compile(
+        _REGEX_TEMPLATE.format(opt_patch="", opt_minor=""),
+        re.VERBOSE,
+    )
+    #: Regex for a semver version that might be shorter
+    _REGEX_OPTIONAL_MINOR_AND_PATCH: ClassVar[Pattern[str]] = re.compile(
+        _REGEX_TEMPLATE.format(opt_patch="?", opt_minor="?"),
+        re.VERBOSE,
+    )
+
+    def __init__(
+        self,
+        major: SupportsInt,
+        minor: SupportsInt = 0,
+        patch: SupportsInt = 0,
+        prerelease: Optional[Union[String, int]] = None,
+        build: Optional[Union[String, int]] = None,
+    ):
+        # Build a dictionary of the arguments except prerelease and build
+        version_parts = {"major": int(major), "minor": int(minor), "patch": int(patch)}
+
+        for name, value in version_parts.items():
+            if value < 0:
+                raise ValueError(
+                    "{!r} is negative. A version can only be positive.".format(name)
+                )
+
+        self._major = version_parts["major"]
+        self._minor = version_parts["minor"]
+        self._patch = version_parts["patch"]
+        self._prerelease = None if prerelease is None else str(prerelease)
+        self._build = None if build is None else str(build)
+
+    @classmethod
+    def _nat_cmp(cls, a, b):  # TODO: type hints
+        def cmp_prerelease_tag(a, b):
+            if isinstance(a, int) and isinstance(b, int):
+                return _cmp(a, b)
+            elif isinstance(a, int):
+                return -1
+            elif isinstance(b, int):
+                return 1
+            else:
+                return _cmp(a, b)
+
+        a, b = a or "", b or ""
+        a_parts, b_parts = a.split("."), b.split(".")
+        a_parts = [int(x) if re.match(r"^\d+$", x) else x for x in a_parts]
+        b_parts = [int(x) if re.match(r"^\d+$", x) else x for x in b_parts]
+        for sub_a, sub_b in zip(a_parts, b_parts):
+            cmp_result = cmp_prerelease_tag(sub_a, sub_b)
+            if cmp_result != 0:
+                return cmp_result
+        else:
+            return _cmp(len(a), len(b))
+
+    @property
+    def major(self) -> int:
+        """The major part of a version (read-only)."""
+        return self._major
+
+    @major.setter
+    def major(self, value):
+        raise AttributeError("attribute 'major' is readonly")
+
+    @property
+    def minor(self) -> int:
+        """The minor part of a version (read-only)."""
+        return self._minor
+
+    @minor.setter
+    def minor(self, value):
+        raise AttributeError("attribute 'minor' is readonly")
+
+    @property
+    def patch(self) -> int:
+        """The patch part of a version (read-only)."""
+        return self._patch
+
+    @patch.setter
+    def patch(self, value):
+        raise AttributeError("attribute 'patch' is readonly")
+
+    @property
+    def prerelease(self) -> Optional[str]:
+        """The prerelease part of a version (read-only)."""
+        return self._prerelease
+
+    @prerelease.setter
+    def prerelease(self, value):
+        raise AttributeError("attribute 'prerelease' is readonly")
+
+    @property
+    def build(self) -> Optional[str]:
+        """The build part of a version (read-only)."""
+        return self._build
+
+    @build.setter
+    def build(self, value):
+        raise AttributeError("attribute 'build' is readonly")
+
+    def to_tuple(self) -> VersionTuple:
+        """
+        Convert the Version object to a tuple.
+
+        .. versionadded:: 2.10.0
+           Renamed :meth:`Version._astuple` to :meth:`Version.to_tuple` to
+           make this function available in the public API.
+
+        :return: a tuple with all the parts
+
+        >>> semver.Version(5, 3, 1).to_tuple()
+        (5, 3, 1, None, None)
+        """
+        return (self.major, self.minor, self.patch, self.prerelease, self.build)
+
+    def to_dict(self) -> VersionDict:
+        """
+        Convert the Version object to an dict.
+
+        .. versionadded:: 2.10.0
+           Renamed :meth:`Version._asdict` to :meth:`Version.to_dict` to
+           make this function available in the public API.
+
+        :return: an dict with the keys in the order ``major``, ``minor``,
+          ``patch``, ``prerelease``, and ``build``.
+
+        >>> semver.Version(3, 2, 1).to_dict()
+        {'major': 3, 'minor': 2, 'patch': 1, 'prerelease': None, 'build': None}
+        """
+        return dict(
+            major=self.major,
+            minor=self.minor,
+            patch=self.patch,
+            prerelease=self.prerelease,
+            build=self.build,
+        )
+
+    def __iter__(self) -> VersionIterator:
+        """Return iter(self)."""
+        yield from self.to_tuple()
+
+    @staticmethod
+    def _increment_string(string: str) -> str:
+        """
+        Look for the last sequence of number(s) in a string and increment.
+
+        :param string: the string to search for.
+        :return: the incremented string
+
+        Source:
+        http://code.activestate.com/recipes/442460-increment-numbers-in-a-string/#c1
+        """
+        match = Version._LAST_NUMBER.search(string)
+        if match:
+            next_ = str(int(match.group(1)) + 1)
+            start, end = match.span(1)
+            string = string[: max(end - len(next_), start)] + next_ + string[end:]
+        return string
+
+    def bump_major(self) -> "Version":
+        """
+        Raise the major part of the version, return a new object but leave self
+        untouched.
+
+        :return: new object with the raised major part
+
+        >>> ver = semver.parse("3.4.5")
+        >>> ver.bump_major()
+        Version(major=4, minor=0, patch=0, prerelease=None, build=None)
+        """
+        cls = type(self)
+        return cls(self._major + 1)
+
+    def bump_minor(self) -> "Version":
+        """
+        Raise the minor part of the version, return a new object but leave self
+        untouched.
+
+        :return: new object with the raised minor part
+
+        >>> ver = semver.parse("3.4.5")
+        >>> ver.bump_minor()
+        Version(major=3, minor=5, patch=0, prerelease=None, build=None)
+        """
+        cls = type(self)
+        return cls(self._major, self._minor + 1)
+
+    def bump_patch(self) -> "Version":
+        """
+        Raise the patch part of the version, return a new object but leave self
+        untouched.
+
+        :return: new object with the raised patch part
+
+        >>> ver = semver.parse("3.4.5")
+        >>> ver.bump_patch()
+        Version(major=3, minor=4, patch=6, prerelease=None, build=None)
+        """
+        cls = type(self)
+        return cls(self._major, self._minor, self._patch + 1)
+
+    def bump_prerelease(self, token: Optional[str] = "rc") -> "Version":
+        """
+        Raise the prerelease part of the version, return a new object but leave
+        self untouched.
+
+        :param token: defaults to ``'rc'``
+        :return: new :class:`Version` object with the raised prerelease part.
+            The original object is not modified.
+
+        >>> ver = semver.parse("3.4.5")
+        >>> ver.bump_prerelease().prerelease
+        'rc.2'
+        >>> ver.bump_prerelease('').prerelease
+        '1'
+        >>> ver.bump_prerelease(None).prerelease
+        'rc.1'
+        """
+        cls = type(self)
+        if self._prerelease is not None:
+            prerelease = self._prerelease
+        elif token == "":
+            prerelease = "0"
+        elif token is None:
+            prerelease = "rc.0"
+        else:
+            prerelease = str(token) + ".0"
+
+        prerelease = cls._increment_string(prerelease)
+        return cls(self._major, self._minor, self._patch, prerelease)
+
+    def bump_build(self, token: Optional[str] = "build") -> "Version":
+        """
+        Raise the build part of the version, return a new object but leave self
+        untouched.
+
+        :param token: defaults to ``'build'``
+        :return: new :class:`Version` object with the raised build part.
+            The original object is not modified.
+
+        >>> ver = semver.parse("3.4.5-rc.1+build.9")
+        >>> ver.bump_build()
+        Version(major=3, minor=4, patch=5, prerelease='rc.1', \
+build='build.10')
+        """
+        cls = type(self)
+        if self._build is not None:
+            build = self._build
+        elif token == "":
+            build = "0"
+        elif token is None:
+            build = "build.0"
+        else:
+            build = str(token) + ".0"
+
+        # self._build or (token or "build") + ".0"
+        build = cls._increment_string(build)
+        if self._build is not None:
+            build = self._build
+        elif token == "":
+            build = "0"
+        elif token is None:
+            build = "build.0"
+        else:
+            build = str(token) + ".0"
+
+        # self._build or (token or "build") + ".0"
+        build = cls._increment_string(build)
+        return cls(self._major, self._minor, self._patch, self._prerelease, build)
+
+    def compare(self, other: Comparable) -> int:
+        """
+        Compare self with other.
+
+        :param other: the second version
+        :return: The return value is negative if ver1 < ver2,
+             zero if ver1 == ver2 and strictly positive if ver1 > ver2
+
+        >>> semver.compare("2.0.0")
+        -1
+        >>> semver.compare("1.0.0")
+        1
+        >>> semver.compare("2.0.0")
+        0
+        >>> semver.compare(dict(major=2, minor=0, patch=0))
+        0
+        """
+        cls = type(self)
+        if isinstance(other, String.__args__):  # type: ignore
+            other = cls.parse(other)
+        elif isinstance(other, dict):
+            other = cls(**other)
+        elif isinstance(other, (tuple, list)):
+            other = cls(*other)
+        elif not isinstance(other, cls):
+            raise TypeError(
+                f"Expected str, bytes, dict, tuple, list, or {cls.__name__} instance, "
+                f"but got {type(other)}"
+            )
+
+        v1 = self.to_tuple()[:3]
+        v2 = other.to_tuple()[:3]
+        x = _cmp(v1, v2)
+        if x:
+            return x
+
+        rc1, rc2 = self.prerelease, other.prerelease
+        rccmp = self._nat_cmp(rc1, rc2)
+
+        if not rccmp:
+            return 0
+        if not rc1:
+            return 1
+        elif not rc2:
+            return -1
+
+        return rccmp
+
+    def next_version(self, part: str, prerelease_token: str = "rc") -> "Version":
+        """
+        Determines next version, preserving natural order.
+
+        .. versionadded:: 2.10.0
+
+        This function is taking prereleases into account.
+        The "major", "minor", and "patch" raises the respective parts like
+        the ``bump_*`` functions. The real difference is using the
+        "prerelease" part. It gives you the next patch version of the
+        prerelease, for example:
+
+        >>> str(semver.parse("0.1.4").next_version("prerelease"))
+        '0.1.5-rc.1'
+
+        :param part: One of "major", "minor", "patch", or "prerelease"
+        :param prerelease_token: prefix string of prerelease, defaults to 'rc'
+        :return: new object with the appropriate part raised
+        """
+        cls = type(self)
+        # "build" is currently not used, that's why we use [:-1]
+        validparts = cls.NAMES[:-1]
+        if part not in validparts:
+            raise ValueError(
+                f"Invalid part. Expected one of {validparts}, but got {part!r}"
+            )
+        version = self
+        if (version.prerelease or version.build) and (
+            part == "patch"
+            or (part == "minor" and version.patch == 0)
+            or (part == "major" and version.minor == version.patch == 0)
+        ):
+            return version.replace(prerelease=None, build=None)
+
+        # Only check the main parts:
+        if part in cls.NAMES[:3]:
+            return getattr(version, "bump_" + part)()
+
+        if not version.prerelease:
+            version = version.bump_patch()
+        return version.bump_prerelease(prerelease_token)
+
+    @_comparator
+    def __eq__(self, other: Comparable) -> bool:  # type: ignore
+        return self.compare(other) == 0
+
+    @_comparator
+    def __ne__(self, other: Comparable) -> bool:  # type: ignore
+        return self.compare(other) != 0
+
+    @_comparator
+    def __lt__(self, other: Comparable) -> bool:
+        return self.compare(other) < 0
+
+    @_comparator
+    def __le__(self, other: Comparable) -> bool:
+        return self.compare(other) <= 0
+
+    @_comparator
+    def __gt__(self, other: Comparable) -> bool:
+        return self.compare(other) > 0
+
+    @_comparator
+    def __ge__(self, other: Comparable) -> bool:
+        return self.compare(other) >= 0
+
+    def __getitem__(
+        self, index: Union[int, slice]
+    ) -> Union[int, Optional[str], Tuple[Union[int, str], ...]]:
+        """
+        self.__getitem__(index) <==> self[index] Implement getitem.
+
+        If the part  requested is undefined, or a part of the range requested
+        is undefined, it will throw an index error.
+        Negative indices are not supported.
+
+        :param index: a positive integer indicating the
+               offset or a :func:`slice` object
+        :raises IndexError: if index is beyond the range or a part is None
+        :return: the requested part of the version at position index
+
+        >>> ver = semver.Version.parse("3.4.5")
+        >>> ver[0], ver[1], ver[2]
+        (3, 4, 5)
+        """
+        if isinstance(index, int):
+            index = slice(index, index + 1)
+        index = cast(slice, index)
+
+        if (
+            isinstance(index, slice)
+            and (index.start is not None and index.start < 0)
+            or (index.stop is not None and index.stop < 0)
+        ):
+            raise IndexError("Version index cannot be negative")
+
+        part = tuple(
+            filter(lambda p: p is not None, cast(Iterable, self.to_tuple()[index]))
+        )
+
+        if len(part) == 1:
+            return part[0]
+        elif not part:
+            raise IndexError("Version part undefined")
+        return part
+
+    def __repr__(self) -> str:
+        s = ", ".join("%s=%r" % (key, val) for key, val in self.to_dict().items())
+        return "%s(%s)" % (type(self).__name__, s)
+
+    def __str__(self) -> str:
+        version = "%d.%d.%d" % (self.major, self.minor, self.patch)
+        if self.prerelease:
+            version += "-%s" % self.prerelease
+        if self.build:
+            version += "+%s" % self.build
+        return version
+
+    def __hash__(self) -> int:
+        return hash(self.to_tuple()[:4])
+
+    def finalize_version(self) -> "Version":
+        """
+        Remove any prerelease and build metadata from the version.
+
+        :return: a new instance with the finalized version string
+
+        >>> str(semver.Version.parse('1.2.3-rc.5').finalize_version())
+        '1.2.3'
+        """
+        cls = type(self)
+        return cls(self.major, self.minor, self.patch)
+
+    def match(self, match_expr: str) -> bool:
+        """
+        Compare self to match a match expression.
+
+        :param match_expr: optional operator and version; valid operators are
+              ``<``   smaller than
+              ``>``   greater than
+              ``>=``  greator or equal than
+              ``<=``  smaller or equal than
+              ``==``  equal
+              ``!=``  not equal
+        :return: True if the expression matches the version, otherwise False
+
+        >>> semver.Version.parse("2.0.0").match(">=1.0.0")
+        True
+        >>> semver.Version.parse("1.0.0").match(">1.0.0")
+        False
+        >>> semver.Version.parse("4.0.4").match("4.0.4")
+        True
+        """
+        prefix = match_expr[:2]
+        if prefix in (">=", "<=", "==", "!="):
+            match_version = match_expr[2:]
+        elif prefix and prefix[0] in (">", "<"):
+            prefix = prefix[0]
+            match_version = match_expr[1:]
+        elif match_expr and match_expr[0] in "0123456789":
+            prefix = "=="
+            match_version = match_expr
+        else:
+            raise ValueError(
+                "match_expr parameter should be in format <op><ver>, "
+                "where <op> is one of "
+                "['<', '>', '==', '<=', '>=', '!=']. "
+                "You provided: %r" % match_expr
+            )
+
+        possibilities_dict = {
+            ">": (1,),
+            "<": (-1,),
+            "==": (0,),
+            "!=": (-1, 1),
+            ">=": (0, 1),
+            "<=": (-1, 0),
+        }
+
+        possibilities = possibilities_dict[prefix]
+        cmp_res = self.compare(match_version)
+
+        return cmp_res in possibilities
+
+    @classmethod
+    def parse(
+        cls: Type[T], version: String, optional_minor_and_patch: bool = False
+    ) -> T:
+        """
+        Parse version string to a Version instance.
+
+        .. versionchanged:: 2.11.0
+           Changed method from static to classmethod to
+           allow subclasses.
+        .. versionchanged:: 3.0.0
+           Added optional parameter ``optional_minor_and_patch`` to allow
+           optional minor and patch parts.
+
+        :param version: version string
+        :param optional_minor_and_patch: if set to true, the version string to parse \
+           can contain optional minor and patch parts. Optional parts are set to zero.
+           By default (False), the version string to parse has to follow the semver
+           specification.
+        :return: a new :class:`Version` instance
+        :raises ValueError: if version is invalid
+        :raises TypeError: if version contains the wrong type
+
+        >>> semver.Version.parse('3.4.5-pre.2+build.4')
+        Version(major=3, minor=4, patch=5, \
+prerelease='pre.2', build='build.4')
+        """
+        if isinstance(version, bytes):
+            version = version.decode("UTF-8")
+        elif not isinstance(version, String.__args__):  # type: ignore
+            raise TypeError("not expecting type '%s'" % type(version))
+
+        if optional_minor_and_patch:
+            match = cls._REGEX_OPTIONAL_MINOR_AND_PATCH.match(version)
+        else:
+            match = cls._REGEX.match(version)
+        if match is None:
+            raise ValueError(f"{version} is not valid SemVer string")
+
+        matched_version_parts: Dict[str, Any] = match.groupdict()
+        if not matched_version_parts["minor"]:
+            matched_version_parts["minor"] = 0
+        if not matched_version_parts["patch"]:
+            matched_version_parts["patch"] = 0
+
+        return cls(**matched_version_parts)
+
+    def replace(self, **parts: Union[int, Optional[str]]) -> "Version":
+        """
+        Replace one or more parts of a version and return a new :class:`Version`
+        object, but leave self untouched.
+
+        .. versionadded:: 2.9.0
+           Added :func:`Version.replace`
+
+        :param parts: the parts to be updated. Valid keys are:
+          ``major``, ``minor``, ``patch``, ``prerelease``, or ``build``
+        :return: the new :class:`~semver.version.Version` object with
+          the changed parts
+        :raises TypeError: if ``parts`` contain invalid keys
+        """
+        version = self.to_dict()
+        version.update(parts)
+        try:
+            return type(self)(**version)  # type: ignore
+        except TypeError:
+            unknownkeys = set(parts) - set(self.to_dict())
+            error = "replace() got %d unexpected keyword argument(s): %s" % (
+                len(unknownkeys),
+                ", ".join(unknownkeys),
+            )
+            raise TypeError(error)
+
+    @classmethod
+    def is_valid(cls, version: str) -> bool:
+        """
+        Check if the string is a valid semver version.
+
+        .. versionadded:: 2.9.1
+
+        .. versionchanged:: 3.0.0
+           Renamed from :meth:`~semver.version.Version.isvalid`
+
+        :param version: the version string to check
+        :return: True if the version string is a valid semver version, False
+                 otherwise.
+        """
+        try:
+            cls.parse(version)
+            return True
+        except ValueError:
+            return False
+
+    def is_compatible(self, other: "Version") -> bool:
+        """
+        Check if current version is compatible with other version.
+
+        The result is True, if either of the following is true:
+
+        * both versions are equal, or
+        * both majors are equal and higher than 0. Same for both minors.
+          Both pre-releases are equal, or
+        * both majors are equal and higher than 0. The minor of b's
+          minor version is higher then a's. Both pre-releases are equal.
+
+        The algorithm does *not* check patches.
+
+        .. versionadded:: 3.0.0
+
+        :param other: the version to check for compatibility
+        :return: True, if ``other`` is compatible with the old version,
+                 otherwise False
+
+        >>> Version(1, 1, 0).is_compatible(Version(1, 0, 0))
+        False
+        >>> Version(1, 0, 0).is_compatible(Version(1, 1, 0))
+        True
+        """
+        if not isinstance(other, Version):
+            raise TypeError(f"Expected a Version type but got {type(other)}")
+
+        # All major-0 versions should be incompatible with anything but itself
+        if (0 == self.major == other.major) and (self[:4] != other[:4]):
+            return False
+
+        return (
+            (self.major == other.major)
+            and (other.minor >= self.minor)
+            and (self.prerelease == other.prerelease)
+        )
+
+
+#: Keep the VersionInfo name for compatibility
+VersionInfo = Version


### PR DESCRIPTION
This PR will allow for update/downgrade of dependencies when needed.

- use one pip call to install dependencies. It allows to correctly handle constraints.
- when package is outside of constraints, perform clean installation. Clean installation in most cases is not necessary but with --target it has strange corner cases.
  - fox example when you are not doing clean install, but only upgrader with `pip install --upgrade` you can only downgrade package...
- commit semver dependency with code

This PR should be pretty complete.