### PR TITLE
Remove clashes with legacy version when linking extension

### DIFF
--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -71,7 +71,6 @@ def _link_addon_or_extension(addon_info: AddonInfo) -> Path:
         else:
             # blender does not know about extension, and it must be linked to default location
             _remove_duplicate_extension_links(addon_info)
-            # remove clashes with legacy version of this addon from other blender versions
             _remove_duplicate_addon_links(addon_info)
             os.makedirs(_EXTENSIONS_DEFAULT_DIR, exist_ok=True)
             load_path = _EXTENSIONS_DEFAULT_DIR / addon_info.module_name

--- a/pythonFiles/include/blender_vscode/load_addons.py
+++ b/pythonFiles/include/blender_vscode/load_addons.py
@@ -71,6 +71,8 @@ def _link_addon_or_extension(addon_info: AddonInfo) -> Path:
         else:
             # blender does not know about extension, and it must be linked to default location
             _remove_duplicate_extension_links(addon_info)
+            # remove clashes with legacy version of this addon from other blender versions
+            _remove_duplicate_addon_links(addon_info)
             os.makedirs(_EXTENSIONS_DEFAULT_DIR, exist_ok=True)
             load_path = _EXTENSIONS_DEFAULT_DIR / addon_info.module_name
             create_link_in_user_addon_directory(addon_info.load_dir, load_path)


### PR DESCRIPTION
Fixes #209. This would occur when an addon containing both bl_info and blender_manifest was linked while using Blender < 4.2 and later using Blender 4.2+. Then there would be two installations of the same addon (one legacy and one extension) loaded into Blender 4.2+ which is undesirable.