### PR TITLE
README.md : Specify that commands must be launched in the Visual Studio Code's Command Palette.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If your addon is a single `.py` file, you have to convert it first.
 To do this, move the file into a new empty folder and rename it to `__init__.py`.
 
 To use the extension with your addon, just load the addon folder into Visual Studio Code.
-Then execute the `Blender: Start` command.
+In Visual Studio Code, open the Command Palette (with CTRL + SHIFT + P) then execute the `Blender: Start` command.
 This will ask you for a path to a Blender executable.
 
 Only Blender 2.8.34 onwards is supported.
@@ -57,7 +57,7 @@ VS code uses the [automatic logic to determine if you are using addon or extensi
 
 ### How can I reload my addon in Blender?
 
-Execute the `Blender: Reload Addons` command.
+Execute the `Blender: Reload Addons` command in VS Code's Command Palette.
 For that to work, Blender has to be started using the extension.
 Your addon does not need to support reloading itself.
 It only has to have correct `register` and `unregister` methods.
@@ -106,7 +106,7 @@ Use VS Code feature [Multi-root Workspaces](https://code.visualstudio.com/docs/e
 
 ### How can I debug into third party library code from within my addon code?
 
-Addon can be debugged when started from VS Code using the `Blender: Start` command. 
+Addon can be debugged when started from VS Code using the `Blender: Start` command in VS Code's Command Palette.
 By default, debug breakpoints work only for files and directories opened in the current workspace and it is also not possible to step into code that is not part of the workspace.
 Disable the VS Code setting [`blender.addon.justMyCode`](vscode://settings/blender.addon.justMyCode) to debug code anywhere.
 In rare cases debugging with VS Code can crash Blender (ex. https://github.com/JacquesLucke/blender_vscode/issues/188).
@@ -127,7 +127,7 @@ For script writing this extension offers
 
 ### How can I create a new script?
 
-Execute the `Blender: New Script` command.
+Execute the `Blender: New Script` command in VS Code's Command Palette.
 You will be asked for a folder to save the script and a script name.
 For quick tests you can also just use the given default name.
 
@@ -135,7 +135,7 @@ The new script file already contains a little bit of code to make it easier to g
 
 ### How can I run the script in Blender?
 
-First you have to start a Blender instance by executing the `Blender: Start` command.
+First you have to start a Blender instance by executing the `Blender: Start` command in VS Code's Command Palette.
 To execute the script in all Blender instances that have been started this way, execute the `Blender: Run Script` command.
 
 ### How can I change the context the script runs in?


### PR DESCRIPTION
Specify that commands must be launched in the Visual Studio Code's Command Palette.