### PR TITLE
Added StartWinCMD to launch Blender within a windows CMD /k shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "activationEvents": [
     "onCommand:blender.start",
+    "onCommand:blender.startWinCMD",
     "onCommand:blender.stop",
     "onCommand:blender.build",
     "onCommand:blender.buildAndStart",
@@ -41,6 +42,11 @@
         "title": "Start",
         "category": "Blender"
       },
+      {
+				"command": "blender.startWinCMD",
+				"title": "Start in Windows CMD",
+				"category": "Blender"
+			},
       {
         "command": "blender.stop",
         "title": "Stop",

--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -35,6 +35,19 @@ export class BlenderExecutable {
         return new BlenderExecutable(data);
     }
 
+    static async GetAnyWinCMD() {
+        let data = await getFilteredBlenderPath({
+            label: 'Blender Executable',
+            selectNewLabel: 'Choose a new Blender executable...',
+            predicate: () => true,
+            setSettings: () => { }
+        });
+        // const modifiedData = `cmd /k "${data}"`;
+        const modifiedData = data;
+        return new BlenderExecutable(modifiedData);
+    }
+
+
     public static async GetDebug() {
         let data = await getFilteredBlenderPath({
             label: 'Debug Build',
@@ -47,6 +60,10 @@ export class BlenderExecutable {
 
     public static async LaunchAny() {
         await (await this.GetAny()).launch();
+    }
+
+    static async LaunchAnyWinCMD() {
+        await (await this.GetAnyWinCMD()).launchWinCMD();
     }
 
     public static async LaunchDebug(folder: BlenderWorkspaceFolder) {
@@ -69,6 +86,27 @@ export class BlenderExecutable {
 
         await runTask('blender', execution);
     }
+
+    async launchWinCMD() {
+        try {
+            const blenderArgs = await getBlenderLaunchArgs();
+            const envVars = await getBlenderLaunchEnv();
+    
+            // Construct the full command to run
+            const command = 'cmd';
+            const commandArgs = ['/k', this.path, ...blenderArgs];
+    
+            let execution = new vscode.ProcessExecution(command, commandArgs, { env: envVars });
+    
+            extension_1.outputChannel.appendLine(`Starting blender in Win CMD: cmd /k ${this.path} ${blenderArgs.join(' ')}`);
+            extension_1.outputChannel.appendLine('With ENV Vars: ' + JSON.stringify(envVars, undefined, 2));
+    
+            await utils_1.runTask('blender', execution);
+        } catch (error) {
+            extension_1.outputChannel.appendLine(`Error launching Blender: ${error.message}`);
+        }
+    }
+
 
     public async launchDebug(folder: BlenderWorkspaceFolder) {
         const env = await getBlenderLaunchEnv();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     let commands: [string, () => Promise<void>][] = [
         ['blender.start', COMMAND_start],
+        ['blender.startWinCMD', COMMAND_startWinCMD],
         ['blender.stop', COMMAND_stop],
         ['blender.build', COMMAND_build],
         ['blender.buildAndStart', COMMAND_buildAndStart],
@@ -82,6 +83,16 @@ async function COMMAND_start() {
     }
     else {
         await BlenderExecutable.LaunchDebug(blenderFolder);
+    }
+}
+
+async function COMMAND_startWinCMD() {
+    let blenderFolder = await blender_folder_1.BlenderWorkspaceFolder.Get();
+    if (blenderFolder === null) {
+        await blender_executable_1.BlenderExecutable.LaunchAnyWinCMD();
+    }
+    else {
+        await blender_executable_1.BlenderExecutable.LaunchDebug(blenderFolder);
     }
 }
 


### PR DESCRIPTION
This is a simple way to get blender launched within a CMD /k windows shell.
This allows to have the terminal always attached so if the python scripts/addon in Blender call os.execv, the output is still going to this shell.

See: https://github.com/JacquesLucke/blender_vscode/issues/223
Thanks!
