### PR TITLE
Remove cpp dependency and related commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Removed
+
+- Removed dependency on `ms-vscode.cpptools` what causes problems for other editors #235, #157. There is no plans to further support Blender Core develompent in this addon.
+- Deprecated setting: `blender.core.buildDebugCommand`
+- Removed commands:
+  - `blender.build`
+  - `blender.buildAndStart`
+  - `blender.startWithoutCDebugger`
+
 ## [0.0.26] - 2025-08-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -133,11 +133,7 @@
                 "name": {
                   "type": "string",
                   "description": "Custom name for this Blender version."
-                },
-                "isDebug": {
-                  "type": "boolean",
-                  "description": "Is this executable a debug build.",
-                  "default": false
+                
                 }
               }
             }
@@ -216,7 +212,8 @@
             "type": "string",
             "scope": "resource",
             "description": "Command used to compile Blender.",
-            "default": "make debug"
+            "default": "make debug",
+            "deprecationMessage": "Removed in version 0.0.27"
           },
           "blender.scripts.directories": {
             "type": "array",
@@ -372,7 +369,6 @@
     "request": "^2.87.0"
   },
   "extensionDependencies": [
-    "ms-python.python",
-    "ms-vscode.cpptools"
+    "ms-python.python"
   ]
 }

--- a/src/blender_folder.ts
+++ b/src/blender_folder.ts
@@ -29,18 +29,6 @@ export class BlenderWorkspaceFolder {
         return this.folder.uri;
     }
 
-    get buildDebugCommand() {
-        return <string>this.getConfig().get('core.buildDebugCommand');
-    }
-
-    public async buildDebug() {
-        let execution = new vscode.ShellExecution(
-            this.buildDebugCommand,
-            { cwd: this.uri.fsPath }
-        );
-        await runTask('Build Blender', execution, true, this.folder);
-    }
-
     public async buildPythonDocs(part: string | undefined = undefined) {
         let api_folder = path.join(this.uri.fsPath, 'doc', 'python_api');
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,9 +27,6 @@ export function activate(context: vscode.ExtensionContext) {
 
     let commands: [string, () => Promise<void>][] = [
         ['blender.stop', COMMAND_stop],
-        ['blender.build', COMMAND_build],
-        ['blender.buildAndStart', COMMAND_buildAndStart],
-        ['blender.startWithoutCDebugger', COMMAND_startWithoutCDebugger],
         ['blender.buildPythonApiDocs', COMMAND_buildPythonApiDocs],
         ['blender.reloadAddons', COMMAND_reloadAddons],
         ['blender.newAddon', COMMAND_newAddon],
@@ -81,11 +78,6 @@ export function deactivate() {
 /* Commands
  *********************************************/
 
-async function COMMAND_buildAndStart() {
-    await COMMAND_build();
-    await COMMAND_start(undefined);
-}
-
 type StartCommandArguments = {
     blenderExecutable?: BlenderExecutableData;
     // additionalArguments?: string[]; // support someday
@@ -104,17 +96,6 @@ async function COMMAND_start(args?: StartCommandArguments) {
             await BlenderExecutable.LaunchAny(executable, undefined)
         } else {
             await BlenderExecutable.LaunchAnyInteractive()
-        }
-    } else {
-        if (args !== undefined && args.blenderExecutable !== undefined) {
-            if (args.blenderExecutable.path === undefined) {
-                await BlenderExecutable.LaunchDebugInteractive(blenderFolder, undefined)
-                return
-            }
-            const executable = new BlenderExecutable(args.blenderExecutable)
-            await BlenderExecutable.LaunchDebug(executable, blenderFolder, undefined)
-        } else {
-            await BlenderExecutable.LaunchDebugInteractive(blenderFolder, undefined)
         }
     }
 }
@@ -142,26 +123,10 @@ async function startBlender(blend_filepaths?: string[]) {
     if (blenderFolder === null) {
         await BlenderExecutable.LaunchAnyInteractive(blend_filepaths);
     }
-    else {
-        await BlenderExecutable.LaunchDebugInteractive(blenderFolder, blend_filepaths);
-    }
 }
 
 async function COMMAND_stop() {
     RunningBlenders.sendToAll({ type: 'stop' });
-}
-
-async function COMMAND_build() {
-    await rebuildAddons(await AddonWorkspaceFolder.All());
-
-    let blenderFolder = await BlenderWorkspaceFolder.Get();
-    if (blenderFolder !== null) {
-        await blenderFolder.buildDebug();
-    }
-}
-
-async function COMMAND_startWithoutCDebugger() {
-    await BlenderExecutable.LaunchAnyInteractive();
 }
 
 async function COMMAND_buildPythonApiDocs() {


### PR DESCRIPTION
Looking for feedback.

A draft PR to review impact of removing `ms-vscode.cpptools` dependency for VS code. it casues issues for forks of VS code:  #235, #157.

In other words, drop support for Blender core development (building from source code) and focus on python-addon related development. 

I do not want to remove useful functionality so maybe it is worth creating new addon before merging this? IDK.

See Changelog file in this PR for details.