### PR TITLE
Add Blender interanal completion for VS code

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,13 @@
             "markdownDeprecationMessage": "**Deprecated**: modules are now installed to `bpy.utils.user_resource(\"SCRIPTS\", path=\"modules\")`.",
             "deprecationMessage": "Deprecated: modules are now installed to `bpy.utils.user_resource(\"SCRIPTS\", path=\"modules\")`."
           },
+          "blender.autocompletion": {
+            "type": "boolean",
+            "scope": "resource",
+            "default": false,
+            "markdownDescription": "Add basic autocompletion powered by Blender internal (console like) code completion. You must use `Blender: Start` before completion starts working.\n\nRequires restart of extension.\n\nFor classic code completion use `fake-bpy-module` or similar.",
+            "tags": ["experimental"]
+          },
           "blender.addon.reloadOnSave": {
             "type": "boolean",
             "scope": "resource",

--- a/pythonFiles/include/blender_vscode/autocomplete.py
+++ b/pythonFiles/include/blender_vscode/autocomplete.py
@@ -1,0 +1,34 @@
+from pprint import pformat
+
+from .autocomplete_locals import BUILTIN_LOCALS
+from . import log
+import bpy
+
+
+from bl_console_utils.autocomplete import intellisense
+
+complete_locals = {}
+complete_locals.update(BUILTIN_LOCALS)
+
+
+LOG = log.getLogger()
+
+
+def complete(data):
+    line: str = data["line"]
+    current_character: str = data["current_character"]
+
+    resultExpand = intellisense.expand(line=line, cursor=current_character, namespace=complete_locals, private=True)
+    # LOG.info("expand")
+    # LOG.info(resultExpand)
+
+    resultComplete = intellisense.complete(line=line, cursor=current_character, namespace=complete_locals, private=True)
+    # LOG.info("complete")
+    # LOG.info(resultComplete)
+
+    if resultComplete[0]:
+        for result in resultComplete[0]:
+            yield {"complete": result, "description": "", "prefixToRemove": resultComplete[1]}
+    else:
+        yield {"complete": resultExpand[0], "description": resultExpand[2]}
+    # return resultComplete[0]

--- a/pythonFiles/include/blender_vscode/autocomplete_locals.py
+++ b/pythonFiles/include/blender_vscode/autocomplete_locals.py
@@ -1,0 +1,4 @@
+import bpy, bgl, gpu, blf, mathutils
+
+
+BUILTIN_LOCALS = locals()

--- a/pythonFiles/include/blender_vscode/communication.py
+++ b/pythonFiles/include/blender_vscode/communication.py
@@ -86,7 +86,6 @@ def handle_post():
         return POST_HANDLERS[data["type"]](data)
     else:
         LOG.warning(f"Unhandled POST: {data}")
-
     return "OK"
 
 
@@ -98,9 +97,14 @@ def handle_get():
     if data["type"] == "ping":
         pass
     elif data["type"] == "complete":
-        from .blender_complete import complete
+        from .autocomplete import complete
 
-        return {"items": complete(data)}
+        items = list(complete(data))
+
+        # print("repondings:")
+        out = flask.jsonify({"type": "completeResponse", "items": items})
+        # print(out)
+        return out
     else:
         LOG.warning(f"Unhandled GET: {data}")
     return "OK"

--- a/src/communication.ts
+++ b/src/communication.ts
@@ -48,6 +48,33 @@ export class BlenderInstance {
         });
     }
 
+    async getAsync(data: any): Promise<any> {
+        return new Promise<any>((resolve, reject) => {
+            request.get(this.address, { json: data },
+                (error, response, body) => {
+                    if (error) {
+                        reject(error)
+                        return;
+                    }
+
+                    if (response.statusCode && response.statusCode >= 200 && response.statusCode < 300) {
+                        resolve(body)
+                    } else {
+                        reject(error)
+                        return;
+                    }
+                }
+            );
+            // req.on('end', () => resolve());
+            // req.on('response', (resp: request.Response) => resolve(resp));
+        //     req.on('complete', (resp: request.Response, body?: string | Buffer) => {
+        //          resolve(resp)
+        });
+        //     // req.on('data', (resp: request.Response) => resolve(resp));
+        //     req.on('error', err => { this.connectionErrors.push(err); reject(err); });
+        // });
+    }
+
     async isResponsive(timeout: number = RESPONSIVE_LIMIT_MS) {
         return new Promise<boolean>(resolve => {
             this.ping().then(() => resolve(true)).catch();
@@ -122,10 +149,25 @@ export class RunningBlenderInstances {
         let sentTo: request.Request[] = []
         for (const instance of this.instances) {
             const isResponsive = await instance.isResponsive(timeout)
-            if (!isResponsive)
-                continue
+
+            if (!isResponsive) continue
+
             try {
                 sentTo.push(instance.post(data))
+            } catch { }
+        }
+        return sentTo;
+    }
+
+    async sendGetToResponsive(data: object, timeout: number = RESPONSIVE_LIMIT_MS) {
+        let sentTo: Promise<any>[] = []
+        for (const instance of this.instances) {
+            const isResponsive = await instance.isResponsive(timeout)
+
+            if (!isResponsive) continue
+
+            try {
+                sentTo.push(instance.getAsync(data))
             } catch { }
         }
         return sentTo;
@@ -171,7 +213,6 @@ function SERVER_handleRequest(request: any, response: any) {
                     instance.attachDebugger().then(() => {
                         RunningBlenders.registerInstance(instance)
                         RunningBlenders.getTask(instance.vscodeIdentifier)?.onStartDebugging()
-
                     }
                     )
                     break;
@@ -190,6 +231,11 @@ function SERVER_handleRequest(request: any, response: any) {
                     response.end('OK');
                     break;
                 }
+                // case 'completeResponse': {
+                //     console.log("completeResponse")
+                //     console.log(req)
+                //     break;
+                // }
                 default: {
                     throw new Error('unknown type');
                 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -242,3 +242,54 @@ export function toTitleCase(str: string) {
         text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
     );
 }
+
+// line: my_var = bpy.data.
+// item: bpy.data.user_map(
+// result : user_map(
+export function removeCommonPrefix2(completionItem: string, line: string) {
+    for (let index = line.length; index < line.length; index--) {
+    }
+}
+
+// app_template_paths(*, path=None)
+// bpy.utils.app_template_paths(
+// *, path=None)
+export function removeCommonPrefix(completionItem: string, line: string): string {
+    let i = 0;
+    // while (i < completionItem.length && i < line.length && completionItem[i] === line[i]) {
+    //     i++;
+    // }
+
+    let prefixLenToremove = 0
+    let completionItemCursor = 0
+    while (i < line.length) {
+        if (line[i] === completionItem[completionItemCursor]) {
+            completionItemCursor++
+            prefixLenToremove++
+        } else {
+            completionItemCursor = 0
+            prefixLenToremove = 0
+        }
+        i++;
+    }
+
+    const withoutPrefix = completionItem.slice(prefixLenToremove);
+    return withoutPrefix;
+}
+
+export function guesFuncSignature(text: string) {
+    const lines = text.split("\n");
+
+    if (lines.length < 2) return lines[0] || "";
+
+    const secondLine = lines[1];
+    if (secondLine.includes("(") || secondLine.includes(")")) {
+        console.log("using second line", secondLine)
+        if (secondLine.startsWith(".. method:: ")) {
+            return secondLine.substring(".. method:: ".length);
+        }
+        return secondLine;
+    }
+
+    return lines[0];
+}


### PR DESCRIPTION
It was idea that I had for a while. 
Use the same completion that is available in blender console, but in VS code.

- this is experimental feature under setting `blender.autocompletion` (by default disabled)
- it will work only in simple cases

How to use
1. Enable setting `blender.autocompletion` and restart extension
1. use `blender Start` command
1. In any python file write `bpy.<trigger completion>` (crtl+space in my case)

note: import will be still marked as missing.
note: should not break other completion methods like `fake-bpy-module` but required polishing
note: this method can complete dynamic items like ops, object names

<img width="897" height="187" alt="image" src="https://github.com/user-attachments/assets/2e498a46-eb62-484c-936c-3d2c331a3c59" />
<img width="1272" height="215" alt="image" src="https://github.com/user-attachments/assets/37be5464-a7d5-4a5f-b2f0-0f76b959f767" />
<img width="859" height="226" alt="image" src="https://github.com/user-attachments/assets/8c3b23ca-34a4-4e9b-aec2-091cf11cf72f" />
