### PR TITLE
Add support for additional arguments in keybinding commands

### DIFF
--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -13,7 +13,7 @@ import { outputChannel, showNotificationAddDefault } from './extension';
 import { getBlenderWindows } from './blender_executable_windows';
 import { deduplicateSameHardLinks } from './blender_executable_linux';
 
-export async function LaunchAnyInteractive(blend_filepaths?: string[], script?: string) {
+export async function LaunchAnyInteractive(blend_filepaths?: string[], script?: string, additionalArguments?: string[]) {
     const executable = await getFilteredBlenderPath({
         label: 'Blender Executable',
         selectNewLabel: 'Choose a new Blender executable...',
@@ -21,16 +21,16 @@ export async function LaunchAnyInteractive(blend_filepaths?: string[], script?: 
         setSettings: () => { }
     });
     showNotificationAddDefault(executable);
-    return await LaunchAny(executable, blend_filepaths, script);
+    return await LaunchAny(executable, blend_filepaths, script, additionalArguments);
 }
 
-export async function LaunchAny(executable: BlenderExecutableData, blend_filepaths?: string[], script?: string) {
+export async function LaunchAny(executable: BlenderExecutableData, blend_filepaths?: string[], script?: string, additionalArguments?: string[]) {
     if (blend_filepaths === undefined || !blend_filepaths.length) {
-        await launch(executable, undefined, script);
+        await launch(executable, undefined, script, additionalArguments);
         return;
     }
     for (const blend_filepath of blend_filepaths) {
-        await launch(executable, blend_filepath, script);
+        await launch(executable, blend_filepath, script, additionalArguments);
     }
 }
 
@@ -52,8 +52,8 @@ export class BlenderTask {
     }
 }
 
-export async function launch(data: BlenderExecutableData, blend_filepath?: string, script?: string) {
-    const blenderArgs = getBlenderLaunchArgs(blend_filepath);
+export async function launch(data: BlenderExecutableData, blend_filepath?: string, script?: string, additionalArguments?: string[]) {
+    const blenderArgs = getBlenderLaunchArgs(blend_filepath, additionalArguments);
     const execution = new vscode.ProcessExecution(
         data.path,
         blenderArgs,
@@ -244,7 +244,7 @@ async function testIfPathIsBlender(filepath: string) {
     });
 }
 
-function getBlenderLaunchArgs(blend_filepath?: string) {
+function getBlenderLaunchArgs(blend_filepath?: string, passthroughArgs: string[] = []) {
     const config = getConfig();
     const additional_args: string[] = [];
     if (blend_filepath !== undefined) {
@@ -262,8 +262,14 @@ function getBlenderLaunchArgs(blend_filepath?: string) {
         }
         additional_args.push(blend_filepath);
         additional_args.push(...post_args);
+        if (passthroughArgs && passthroughArgs.length) {
+            additional_args.push(...passthroughArgs);
+        }
     } else {
         additional_args.push(...(<string[]>config.get('additionalArguments', [])));
+        if (passthroughArgs && passthroughArgs.length) {
+            additional_args.push(...passthroughArgs);
+        }
     }
     const args = ['--python', launchPath, ...additional_args];
     return args;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,15 +72,18 @@ export type StartCommandArguments = {
     blendFilepaths?: string[]
     // run python script after degugger is attached
     script?: string
-    // additionalArguments?: string[]; // support someday
+    // extra CLI args passed through to Blender
+    additionalArguments?: string[]
 }
 
 export async function COMMAND_start(args?: StartCommandArguments) {
     let blenderToRun = getDefaultBlenderSettings()
     let filePaths: string[] | undefined = undefined
     let script: string | undefined = undefined
+    let additionalArguments: string[] | undefined = undefined
     if (args !== undefined) {
         script = args.script
+        additionalArguments = args.additionalArguments
         if (args.blenderExecutable !== undefined) {
             if (args.blenderExecutable.path !== undefined) {
                 blenderToRun = args.blenderExecutable
@@ -90,9 +93,9 @@ export async function COMMAND_start(args?: StartCommandArguments) {
     }
 
     if (blenderToRun === undefined) {
-        await LaunchAnyInteractive(filePaths, script)
+        await LaunchAnyInteractive(filePaths, script, additionalArguments)
     } else {
-        await LaunchAny(blenderToRun, filePaths, script)
+        await LaunchAny(blenderToRun, filePaths, script, additionalArguments)
     }
 }
 


### PR DESCRIPTION
This allows users to add the [cli arguments](https://docs.blender.org/manual/en/latest/advanced/command_line/arguments.html) to key bindings in order to create more custom keybindings for their workflows.

## Use as follows:
```json
{
    "key": "ctrl+shift+h",
    "command": "blender.start",
    "args": {
    "additionalArguments": ["--open-last"]
    }
}
```
This will open the last file opened by blender, leaving the normal calls to `blender.start` opening the default scene