### PR TITLE
Fix custom build task exec on Start

### DIFF
--- a/src/blender_executable.ts
+++ b/src/blender_executable.ts
@@ -59,6 +59,11 @@ export async function launch(data: BlenderExecutableData, blend_filepath?: strin
         blenderArgs,
         { env: await getBlenderLaunchEnv() }
     );
+
+    outputChannel.appendLine(`Running custom build tasks (if any).`);
+    const addons = await AddonWorkspaceFolder.All();
+    await Promise.all(addons.map(a => a.buildIfNecessary()));
+
     outputChannel.appendLine(`Starting blender: ${data.path} ${blenderArgs.join(' ')}`);
     outputChannel.appendLine('With ENV Vars: ' + JSON.stringify(execution.options?.env, undefined, 2));
 


### PR DESCRIPTION
The build task that can be set with `buildTaskName` is very handy for addons that use vendorized dependencies.
It works already if the addon is reloaded with running Blender.

But the task is not executed before Blender is initially launched. This also doesn't match the description of the setting:

"Task that should be executed before the addon can be loaded into Blender."